### PR TITLE
Point submodule to GitHub repo; update submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "j-pet-framework"]
 	path = j-pet-framework
-	url = koza.if.uj.edu.pl:/srv/git/j-pet-framework.git
+	url = https://github.com/JPETTomography/j-pet-framework.git


### PR DESCRIPTION
Zaktualizowałem submoduł tak, żeby wskazywał na JPetTomography/j-pet-framework na GitHubie. To samo zrobiłem z develop - zaraz wyślę drugi pull reguest.

Submoduł wskazuje na obecny HEAD z master. W tej wersji obydwa przykłady działają.