### PR TITLE
Change the name of cmake global variable in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@ endif()
 ##download input files and config files
 #only once
 set(DOWNLOAD_DATA ${CMAKE_CURRENT_SOURCE_DIR}/download_data.sh ${CMAKE_CURRENT_SOURCE_DIR})
-if(NOT DOWNLOAD_DATA_HAPPENED)
+if(NOT DOWNLOAD_EXAMPLE_DATA_HAPPENED)
   execute_process( COMMAND ${DOWNLOAD_DATA} )
-  set(DOWNLOAD_DATA_HAPPENED TRUE CACHE BOOL "Has the download data happened?" FORCE)
+  set(DOWNLOAD_EXAMPLE_DATA_HAPPENED TRUE CACHE BOOL "Has the download data happened?" FORCE)
 endif() 
 add_subdirectory(AnalysisExample)
 add_subdirectory(ScopeLoaderExample)


### PR DESCRIPTION
The same name was used in CMakeLists.txt of j-pet-framework which caused the bug.