### PR TITLE
Add downloading of calibration files from sphinx

### DIFF
--- a/download_data.sh
+++ b/download_data.sh
@@ -62,3 +62,9 @@ WGET_DIR=${DIR_LBAE}
 WGET_INPUT=${HTTP_PATH}/${DIR_LBAE}
 #downloading test data via wget
 wget "${WGET_INPUT}" "${WGET_FLAGS[@]}" -P "${WGET_OUTPUT}" 
+
+#calibration files
+DIR_CAL=CalibrationFiles
+WGET_DIR=${DIR_CAL}
+WGET_INPUT=${HTTP_PATH}/${DIR_CAL}
+wget "${WGET_INPUT}" "${WGET_FLAGS[@]}" -P "${WGET_OUTPUT}" 


### PR DESCRIPTION
Calibration files for all three runs are stored on sphinx.
Now they are downloaded and placed in CalibrationFiles directory in main project directory.
Each Run directory contains calibration files for: TOT, time differences, TOF, TRB, channel ids, velocity.
It is assumed that user will copy proper files to his working directory.