### PR TITLE
ScopeLoaderExample uses new ParamGetter

### DIFF
--- a/ScopeLoaderExample/main.cpp
+++ b/ScopeLoaderExample/main.cpp
@@ -20,7 +20,6 @@
 using namespace std;
 int main(int argc, char* argv[])
 {
-	DB::SERVICES::DBHandler::createDBConnection("../DBConfig/configDB.cfg");
   JPetManager& manager = JPetManager::getManager();
   manager.parseCmdLine(argc, argv);
   manager.run();

--- a/ScopeLoaderExample/run.sh
+++ b/ScopeLoaderExample/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./ScopeReaderExample.x -t scope -f ./cfg/example.json
+./ScopeReaderExample.x -t scope -f ./cfg/example.json -l ./cfg/example_params.json -i 1


### PR DESCRIPTION
Changes needed after removing ScopeParamGetter from the framework.