### PR TITLE
Deleted config files

### DIFF
--- a/LargeBarrelAnalysis/CMakeLists.txt
+++ b/LargeBarrelAnalysis/CMakeLists.txt
@@ -15,7 +15,6 @@ set(projectName LargeBarrelAnalysis)
 
 set(AUXILLIARY_FILES
   run.sh
-  conf_trb3.xml
   README
   )
 

--- a/LargeBarrelAnalysisExtended/CMakeLists.txt
+++ b/LargeBarrelAnalysisExtended/CMakeLists.txt
@@ -15,10 +15,6 @@ set(projectName LargeBarrelAnalysisExtended)
 
 set(AUXILLIARY_FILES
   run.sh
-  conf_trb3.xml
-  resultsForThresholda.txt
-  large_barrel.json
-  TimeConstants.txt
   userParams.json
   README
   )


### PR DESCRIPTION
Config files are now not automatically copied from build directories. 
File file user parameters was changed at sphinx to force users to select config files themselves.