### PR TITLE
Fixing tests for LargeBarrelAnalysis

### DIFF
--- a/LargeBarrelAnalysis/CMakeLists.txt
+++ b/LargeBarrelAnalysis/CMakeLists.txt
@@ -102,4 +102,10 @@ foreach(test_source ${UNIT_TEST_SOURCES})
     )
 endforeach()
 
-add_custom_target(tests_LargeBarrel DEPENDS ${test_binaries} )
+# create a symlink to the directory with data necessary for some unit tests
+add_custom_command(OUTPUT ${TESTS_DIR}/unitTestData
+  COMMAND ln -s ${CMAKE_CURRENT_SOURCE_DIR}/../unitTestData ${TESTS_DIR}/unitTestData
+  )
+
+add_custom_target(tests_LargeBarrel DEPENDS ${test_binaries} ${TESTS_DIR}/unitTestData)
+

--- a/LargeBarrelAnalysis/EventCategorizerTools.cpp
+++ b/LargeBarrelAnalysis/EventCategorizerTools.cpp
@@ -17,62 +17,58 @@
 
 Point3D EventCategorizerTools::calculateAnnihilationPoint(const JPetHit& firstHit, const JPetHit& latterHit)
 {
-  Point3D annihilationPoint;
-  annihilationPoint.x = kUndefined::point;
-  annihilationPoint.y = kUndefined::point;
-  annihilationPoint.z = kUndefined::point;
-  
+  Point3D annihilationPoint(EventCategorizerTools::kUndefinedPoint);
+
   Point3D firstHitPoint;
   firstHitPoint.x = firstHit.getPosX();
   firstHitPoint.y = firstHit.getPosY();
   firstHitPoint.z = firstHit.getPosZ();
-  
+
   Point3D latterHitPoint;
   latterHitPoint.x = latterHit.getPosX();
   latterHitPoint.y = latterHit.getPosY();
   latterHitPoint.z = latterHit.getPosZ();
-  
+
   Point3D middleOfLOR;
   middleOfLOR.x = ( firstHitPoint.x + latterHitPoint.x ) / 2.0;
   middleOfLOR.y = ( firstHitPoint.y + latterHitPoint.y ) / 2.0;
   middleOfLOR.z = ( firstHitPoint.z + latterHitPoint.z ) / 2.0;
-  
-  double LORlength = sqrt( pow(( firstHitPoint.x - latterHitPoint.x),2) +
-		    pow((firstHitPoint.y - latterHitPoint.y),2) +
-		    pow((firstHitPoint.z - latterHitPoint.z),2) );
-  
+
+  double LORlength = sqrt(pow(( firstHitPoint.x - latterHitPoint.x), 2) +
+                          pow((firstHitPoint.y - latterHitPoint.y), 2) +
+                          pow((firstHitPoint.z - latterHitPoint.z), 2) );
+
   double versorOnLOR_x, versorOnLOR_y, versorOnLOR_z;  //towards first hit
-  versorOnLOR_x =  fabs( (latterHitPoint.x - firstHitPoint.x)/LORlength );
-  versorOnLOR_y = fabs( (latterHitPoint.y - firstHitPoint.y)/LORlength );
-  versorOnLOR_z = fabs( (latterHitPoint.z - firstHitPoint.z)/LORlength );
-  
+  versorOnLOR_x =  fabs( (latterHitPoint.x - firstHitPoint.x) / LORlength );
+  versorOnLOR_y = fabs( (latterHitPoint.y - firstHitPoint.y) / LORlength );
+  versorOnLOR_z = fabs( (latterHitPoint.z - firstHitPoint.z) / LORlength );
+
   double velocity = 30.0; //cm/ns
-  velocity/=1000; //cm/ps
-  
-  annihilationPoint.x = middleOfLOR.x - versorOnLOR_x* calculateTOF(firstHit, latterHit)*velocity;
-  annihilationPoint.y = middleOfLOR.y - versorOnLOR_y* calculateTOF(firstHit, latterHit)*velocity;
-  annihilationPoint.z = middleOfLOR.z - versorOnLOR_z* calculateTOF(firstHit, latterHit)*velocity;
-  
+  velocity /= 1000; //cm/ps
+
+  annihilationPoint.x = middleOfLOR.x - versorOnLOR_x * calculateTOF(firstHit, latterHit) * velocity;
+  annihilationPoint.y = middleOfLOR.y - versorOnLOR_y * calculateTOF(firstHit, latterHit) * velocity;
+  annihilationPoint.z = middleOfLOR.z - versorOnLOR_z * calculateTOF(firstHit, latterHit) * velocity;
+
   return annihilationPoint;
 }
 
 double EventCategorizerTools::calculateTOF(const JPetHit& firstHit, const JPetHit& latterHit)
 {
-  double TOF = kUndefined::tof;
-  if( firstHit.getTime() > latterHit.getTime() )
-  {
+  double TOF = EventCategorizerTools::kUndefinedTof;
+  if ( firstHit.getTime() > latterHit.getTime() ) {
     ERROR("First hit time should be earlier than later hit");
     return TOF;
   }
-  TOF = firstHit.getTime()-latterHit.getTime();
-  
+  TOF = firstHit.getTime() - latterHit.getTime();
+
   double firstHitSlotAngle = firstHit.getBarrelSlot().getTheta();
   double latterHitSlotAngle = latterHit.getBarrelSlot().getTheta();
-  
-  if( firstHitSlotAngle < latterHitSlotAngle )
+
+  if ( firstHitSlotAngle < latterHitSlotAngle )
     return TOF;
-  else 
-    return -1.0*TOF;
-  
+  else
+    return -1.0 * TOF;
+
   return TOF;
 }

--- a/LargeBarrelAnalysis/EventCategorizerTools.h
+++ b/LargeBarrelAnalysis/EventCategorizerTools.h
@@ -18,21 +18,30 @@
 
 #include <JPetHit/JPetHit.h>
 
-enum kUndefined { point = 999, tof = 9999 };
-
-struct Point3D
+class Point3D
 {
-  double x=0;
-  double y=0;
-  double z=0;
+public:
+  Point3D() : x(0), y(0), z(0) {}
+  Point3D(double initialValue) : x(initialValue), y(initialValue), z(initialValue) {}
+  double x;
+  double y;
+  double z;
 };
-
 
 class EventCategorizerTools
 {
 public:
-    static double calculateTOF(const JPetHit& firstHit, const JPetHit& latterHit);
-    static Point3D calculateAnnihilationPoint(const JPetHit& firstHit, const JPetHit& latterHit);
+
+  static constexpr float kUndefinedPoint = 999;
+  static constexpr float kUndefinedTof = 9999;
+
+  static double calculateTOF(const JPetHit& firstHit, const JPetHit& latterHit);
+  static Point3D calculateAnnihilationPoint(const JPetHit& firstHit, const JPetHit& latterHit);
+
+
+
+private:
+  EventCategorizerTools() = delete;
 };
 
 #endif /*  !EVENTCATEGORIZERTOOLS_H */

--- a/LargeBarrelAnalysis/EventCategorizerToolsTest.cpp
+++ b/LargeBarrelAnalysis/EventCategorizerToolsTest.cpp
@@ -14,10 +14,10 @@ BOOST_AUTO_TEST_CASE(checkHitOrder)
 
   JPetHit secondHit;
   secondHit.setTime(100);
-  
+
   double tof = EventCategorizerTools::calculateTOF(firstHit, secondHit);
-  
-  BOOST_REQUIRE_CLOSE( tof, kUndefined::tof, 0.100);
+  double undefinedTof = EventCategorizerTools::kUndefinedTof;
+  BOOST_REQUIRE_CLOSE(tof, undefinedTof, 0.100);
 }
 
 BOOST_AUTO_TEST_CASE(checkTOFsignNegative)
@@ -26,12 +26,12 @@ BOOST_AUTO_TEST_CASE(checkTOFsignNegative)
   firstHit.setTime(100);
   JPetBarrelSlot firstSlot(1, true, "first", 10, 1);
   firstHit.setBarrelSlot( firstSlot );
-  
+
   JPetHit secondHit;
   secondHit.setTime(500);
   JPetBarrelSlot secondSlot(2, true, "second", 30, 2);
   secondHit.setBarrelSlot(secondSlot);
-  
+
   double tof = EventCategorizerTools::calculateTOF(firstHit, secondHit);
   BOOST_REQUIRE_LT( tof, 0 );
 }
@@ -42,12 +42,12 @@ BOOST_AUTO_TEST_CASE(checkTOFsignPositive)
   firstHit.setTime(100);
   JPetBarrelSlot firstSlot(1, true, "first", 30, 1);
   firstHit.setBarrelSlot( firstSlot );
-  
+
   JPetHit secondHit;
   secondHit.setTime(500);
   JPetBarrelSlot secondSlot(2, true, "second", 10, 2);
   secondHit.setBarrelSlot(secondSlot);
-  
+
   double tof = EventCategorizerTools::calculateTOF(firstHit, secondHit);
   BOOST_REQUIRE_GT( tof, 0 );
 }
@@ -60,16 +60,16 @@ BOOST_AUTO_TEST_CASE(pointAtCenter)
 {
   JPetHit firstHit;
   firstHit.setTime(300);
-  firstHit.setPos(5,5,0);
+  firstHit.setPos(5, 5, 0);
   JPetBarrelSlot firstSlot(1, true, "first", 45, 1);
   firstHit.setBarrelSlot( firstSlot );
-  
+
   JPetHit secondHit;
   secondHit.setTime(300);
-  secondHit.setPos(-5,-5,0);
+  secondHit.setPos(-5, -5, 0);
   JPetBarrelSlot secondSlot(2, true, "second", 225, 2);
   secondHit.setBarrelSlot(secondSlot);
-  
+
   Point3D point = EventCategorizerTools::calculateAnnihilationPoint(firstHit, secondHit);
   BOOST_REQUIRE_CLOSE(point.x, 0, 0.001);
   BOOST_REQUIRE_CLOSE(point.y, 0, 0.001);
@@ -79,17 +79,17 @@ BOOST_AUTO_TEST_CASE(pointAtCenter)
 BOOST_AUTO_TEST_CASE(pointAt0x_5y_0z)
 {
   JPetHit firstHit;
-  firstHit.setTime(1333/2.0);
-  firstHit.setPos(0,45,0);
+  firstHit.setTime(1333 / 2.0);
+  firstHit.setPos(0, 45, 0);
   JPetBarrelSlot firstSlot(1, true, "first", 90, 1);
   firstHit.setBarrelSlot( firstSlot );
-  
+
   JPetHit secondHit;
-  secondHit.setTime(1667/2);
-  secondHit.setPos(0,-45,0);
+  secondHit.setTime(1667 / 2);
+  secondHit.setPos(0, -45, 0);
   JPetBarrelSlot secondSlot(2, true, "second", 270, 2);
   secondHit.setBarrelSlot(secondSlot);
-  
+
   Point3D point = EventCategorizerTools::calculateAnnihilationPoint(firstHit, secondHit);
   BOOST_REQUIRE_CLOSE(point.x, 0, 0.1);
   BOOST_REQUIRE_CLOSE(point.y, 5.0, 0.5);
@@ -100,17 +100,17 @@ BOOST_AUTO_TEST_CASE(pointAt0x_5y_0z)
 BOOST_AUTO_TEST_CASE(pointAt0x_m5y_0z)
 {
   JPetHit firstHit;
-  firstHit.setTime(1333/2.0);
-  firstHit.setPos(0,-45,0);
+  firstHit.setTime(1333 / 2.0);
+  firstHit.setPos(0, -45, 0);
   JPetBarrelSlot firstSlot(1, true, "first", 270, 1);
   firstHit.setBarrelSlot( firstSlot );
-  
+
   JPetHit secondHit;
-  secondHit.setTime(1667/2);
-  secondHit.setPos(0,45,0);
+  secondHit.setTime(1667 / 2);
+  secondHit.setPos(0, 45, 0);
   JPetBarrelSlot secondSlot(2, true, "second", 90, 2);
   secondHit.setBarrelSlot(secondSlot);
-  
+
   Point3D point = EventCategorizerTools::calculateAnnihilationPoint(firstHit, secondHit);
   BOOST_REQUIRE_CLOSE(point.x, 0, 0.1);
   BOOST_REQUIRE_CLOSE(point.y, -5.0, 0.5);

--- a/LargeBarrelAnalysis/SignalFinderTools.cpp
+++ b/LargeBarrelAnalysis/SignalFinderTools.cpp
@@ -33,7 +33,7 @@ map<int, vector<JPetSigCh>> SignalFinderTools::getSigChsPMMapById(const JPetTime
     if (search == sigChsPMMap.end()) {
       vector<JPetSigCh> tmp;
       tmp.push_back(sigCh);
-      sigChsPMMap.insert(pair<int, vector<JPetSigCh>>(pmt_id, tmp));
+      sigChsPMMap.insert(make_pair(pmt_id, tmp));
     } else {
       search->second.push_back(sigCh);
     }

--- a/LargeBarrelAnalysis/SignalFinderToolsTest.cpp
+++ b/LargeBarrelAnalysis/SignalFinderToolsTest.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE( getSigChsPMMapById_nullPointer )
 
 BOOST_AUTO_TEST_CASE( getSigChsPMMapById )
 {
-  JPetTimeWindow window;
+  JPetTimeWindow window("JPetSigCh");
   auto sigCh1 = JPetSigCh(JPetSigCh::Leading, 10);
   sigCh1.setThreshold(1);
   JPetPM pm1(1);

--- a/LargeBarrelAnalysis/TimeCalibToolsTest.cpp
+++ b/LargeBarrelAnalysis/TimeCalibToolsTest.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE (fillTimeCalibRecord_too_few_numbers)
 
 BOOST_AUTO_TEST_CASE (readCalibrationRecordsFromFile)
 {
-  auto result = TimeCalibTools::readCalibrationRecordsFromFile("../TimeConstants_Layer1_2.txt");
+  auto result = TimeCalibTools::readCalibrationRecordsFromFile("unitTestData/TimeConstants_Layer1_2.txt");
   BOOST_REQUIRE_EQUAL(result.size(), 768);
 }
 


### PR DESCRIPTION
Add syslink to unitTestData folder in LargeBarrelAnalysis' test folder, small changes to EventCategorizerTools to make tests work. SignalFinderToolsTests are still not working, null objects are returned from ParamBank.