### PR TITLE
Aux files cleanup

### DIFF
--- a/NewAnalysisTemplate/CMakeLists.txt
+++ b/NewAnalysisTemplate/CMakeLists.txt
@@ -13,12 +13,8 @@ cmake_minimum_required(VERSION 2.6)
 ######################################################################
 set(projectName NewProjectName)
 
-# files to be copied from some other example directory, if any
-set(USE_AUX_FILES_FROM LargeBarrelAnalysis)
-
+# files to be copied from the source directory, if any
 set(AUXILLIARY_FILES
-  run.sh
-  userParams.json
   README
   )
 
@@ -85,7 +81,7 @@ set(copy_depends) #create variable for list with depends files path
 foreach( file_i ${AUXILLIARY_FILES})
   list(APPEND copy_depends ${CMAKE_CURRENT_BINARY_DIR}/${file_i})
 
-  if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../${USE_AUX_FILES_FROM}/${file_i})
+  if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${file_i})
     set(CP_CMD copy_directory)
   else()
     set(CP_CMD copy)
@@ -93,7 +89,7 @@ foreach( file_i ${AUXILLIARY_FILES})
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file_i}
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
-    ARGS -E ${CP_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/../${USE_AUX_FILES_FROM}/${file_i} ${CMAKE_CURRENT_BINARY_DIR}/${file_i}
+    ARGS -E ${CP_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/${file_i} ${CMAKE_CURRENT_BINARY_DIR}/${file_i}
     )
 endforeach( file_i )
 

--- a/NewAnalysisTemplate/README
+++ b/NewAnalysisTemplate/README
@@ -31,4 +31,4 @@ Author
 ------
 
 Aleksander Gajos 
-Please report any bugs and suggestions of corrections to: <alek.gajos@gmail.com>
+Please report any bugs and suggestions of corrections to: <aleksander.gajos@uj.edu.pl>

--- a/TimeCalibration/CMakeLists.txt
+++ b/TimeCalibration/CMakeLists.txt
@@ -13,12 +13,7 @@ cmake_minimum_required(VERSION 2.6)
 ######################################################################
 set(projectName TimeCalibration)
 
-# files to be copied from some other example directory, if any
-set(USE_AUX_FILES_FROM LargeBarrelAnalysis)
-
 set(AUXILLIARY_FILES
-  run.sh
-  userParams.json
   README
   )
 
@@ -88,7 +83,7 @@ set(copy_depends) #create variable for list with depends files path
 foreach( file_i ${AUXILLIARY_FILES})
   list(APPEND copy_depends ${CMAKE_CURRENT_BINARY_DIR}/${file_i})
 
-  if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../${USE_AUX_FILES_FROM}/${file_i})
+  if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${file_i})
     set(CP_CMD copy_directory)
   else()
     set(CP_CMD copy)
@@ -96,7 +91,7 @@ foreach( file_i ${AUXILLIARY_FILES})
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file_i}
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
-    ARGS -E ${CP_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/../${USE_AUX_FILES_FROM}/${file_i} ${CMAKE_CURRENT_BINARY_DIR}/${file_i}
+    ARGS -E ${CP_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/${file_i} ${CMAKE_CURRENT_BINARY_DIR}/${file_i}
     )
 endforeach( file_i )
 


### PR DESCRIPTION
Updating the core repo to the version with universal CMake.
Making all of the examples copy auxilliary files from their own source directories rather than from LargeBarrelAnalysis. (fixes: #951 at Redmine)