### PR TITLE
V5fixes

### DIFF
--- a/LargeBarrelAnalysis/SignalTransformer.cpp
+++ b/LargeBarrelAnalysis/SignalTransformer.cpp
@@ -201,6 +201,12 @@ void SignalTransformer::initialiseHistograms(){
   getStatistics().getHisto1D("good_vs_bad_signals")->GetXaxis()->SetBinLabel(3,"UNKNOWN");
   getStatistics().getHisto1D("good_vs_bad_signals")->GetYaxis()->SetTitle("Number of Signals");
 
+  getStatistics().createHistogram(
+    new TH1F("PmIdCorrupted", "PMs yielding corrupted signals", 400, -0.5, 399.5)
+  );
+  getStatistics().getHisto1D("PmIdCorrupted")->GetXaxis()->SetTitle("PM id");
+  getStatistics().getHisto1D("PmIdCorrupted")->GetYaxis()->SetTitle("Number of Signals");
+  
   getStatistics().createHistogram(new TH1F(
     "raw_sigs_multi", "Multiplicity of created Raw Signals",
     8, 0.5, 8.5

--- a/MCGeantAnalysis/PARAMETERS.md
+++ b/MCGeantAnalysis/PARAMETERS.md
@@ -20,10 +20,6 @@ Create standard analysis histograms
 default value : false
 Create additional set of histograms connected with analysis efficiencies
 
-- "GeantParser_Zresolution_double"
-default value : 0.976
-Value of the Gaussian smearing function along the z~strip
-
 - "GeantParser_EnergyThreshold_double"
 default value [keV] : 10.0
 Energy threshold applied by the electronics - different for different runs, so be careful while
@@ -32,3 +28,5 @@ applying. This value influence on number of reconstructed hits and events.
 - "GeantParser_ProcessSingleEventInWindow_bool"
 default value : false
 For testing purposes user can ask for processing single event per time window
+
+Note that presently there are no parameters allowing to control the smearing of generated hit properties such as interaction time and Z position resolution. In order to tune them, please modify the corresponding functions in the `JPetSmearingFunctions` class directly in the `j-pet-framework` code. User parameters allowing to control the smearing will be added in the future versions.

--- a/MCGeantAnalysis/README.md
+++ b/MCGeantAnalysis/README.md
@@ -7,7 +7,7 @@ Module is used to load a simulation files created with [J-PET-geant4](https://gi
 - Input file must have the `*.mcGeant.root`  
 - Also required is a `.json` which corresponds to simulated/analyzed run.
 Those files are the same as used while processing the data and can be taken from CalibrationFiles/X_RUN/detectorSetupRun.json
-- Output file created   `*.mc.hits.root`  
+- Output file created   `*.hits.root`  
 - No output to stdout,`JPet_(date).log` file appears with the log of the processing and ROOT files.
 
 ## How to use?


### PR DESCRIPTION
* Removed obsoleted parameter from MCGeantAnalysis/PARAMETERS.md and added information about smearing possibility
* Fixed a bug crashing LargeBarrelAnalysis due to a histogram referenced but not created in the module init (thus causing a segmentation fault).