### PR TITLE
Expanding TOT calculations to apply thresholds

### DIFF
--- a/CosmicAnalysis/EventCategorizerCosmic.cpp
+++ b/CosmicAnalysis/EventCategorizerCosmic.cpp
@@ -88,7 +88,7 @@ JPetEvent EventCategorizerCosmic::cosmicAnalysis(vector<JPetHit> hits)
 {
   JPetEvent cosmicEvent;
   for (unsigned i = 0; i < hits.size(); i++) {
-    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i]);
+    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kStandard);
     if (TOTofHit >= fMinCosmicTOT) {
       cosmicEvent.addHit(hits[i]);
       //Uncomment if kCosmic type will be avalible

--- a/CosmicAnalysis/EventCategorizerCosmic.cpp
+++ b/CosmicAnalysis/EventCategorizerCosmic.cpp
@@ -88,7 +88,7 @@ JPetEvent EventCategorizerCosmic::cosmicAnalysis(vector<JPetHit> hits)
 {
   JPetEvent cosmicEvent;
   for (unsigned i = 0; i < hits.size(); i++) {
-    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kStandard);
+    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kSimplified);
     if (TOTofHit >= fMinCosmicTOT) {
       cosmicEvent.addHit(hits[i]);
       //Uncomment if kCosmic type will be avalible

--- a/Imaging/EventCategorizerImaging.cpp
+++ b/Imaging/EventCategorizerImaging.cpp
@@ -191,7 +191,7 @@ JPetEvent EventCategorizerImaging::imageReconstruction(vector<JPetHit> hits)
 {
   JPetEvent imagingEvent;
   for (unsigned i = 0; i < hits.size(); i++) {
-    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kStandard);
+    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kSimplified);
     if (TOTofHit >= fMinAnnihilationTOT && TOTofHit <= fMaxAnnihilationTOT && fabs(hits[i].getPosZ()) < fMaxZPos) {
       imagingEvent.addHit(hits[i]);
     }

--- a/Imaging/EventCategorizerImaging.cpp
+++ b/Imaging/EventCategorizerImaging.cpp
@@ -191,7 +191,7 @@ JPetEvent EventCategorizerImaging::imageReconstruction(vector<JPetHit> hits)
 {
   JPetEvent imagingEvent;
   for (unsigned i = 0; i < hits.size(); i++) {
-    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i]);
+    double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kStandard);
     if (TOTofHit >= fMinAnnihilationTOT && TOTofHit <= fMaxAnnihilationTOT && fabs(hits[i].getPosZ()) < fMaxZPos) {
       imagingEvent.addHit(hits[i]);
     }

--- a/LargeBarrelAnalysis/EventCategorizerTools.h
+++ b/LargeBarrelAnalysis/EventCategorizerTools.h
@@ -33,9 +33,9 @@ class EventCategorizerTools
 public:
   enum TOTCalculationType
   {
-    kStandard,
-    kAdjustedToThresholds,
-    kAdjustedToThresholdsExtended
+    kSimplified,
+    kThresholdRectangular,
+    kThresholdTrapeze
   };    
 
   static bool checkFor2Gamma(const JPetEvent& event, JPetStatistics& stats,
@@ -45,7 +45,9 @@ public:
                              bool saveHistos, double deexTOTCutMin, double deexTOTCutMax);
   static bool checkForScatter(const JPetEvent& event, JPetStatistics& stats,
                               bool saveHistos, double scatterTOFTimeDiff);
-  static double calculateTOT(const JPetHit& hit, TOTCalculationType type);
+  static double calculateTOT(const JPetHit& hit, TOTCalculationType type = TOTCalculationType::kSimplified);
+  static double calculateTOTside(const std::vector<JPetSigCh> & leadPoints, 
+                            const std::vector<JPetSigCh> & trailPoints, TOTCalculationType type);
   static double calculateDistance(const JPetHit& hit1, const JPetHit& hit2);
   static double calculateScatteringTime(const JPetHit& hit1, const JPetHit& hit2);
   static double calculateScatteringAngle(const JPetHit& hit1, const JPetHit& hit2);

--- a/LargeBarrelAnalysis/EventCategorizerTools.h
+++ b/LargeBarrelAnalysis/EventCategorizerTools.h
@@ -31,6 +31,13 @@ static const double kUndefinedValue = 999.0;
 class EventCategorizerTools
 {
 public:
+  enum TOTCalculationType
+  {
+    kStandard,
+    kAdjustedToThresholds,
+    kAdjustedToThresholdsExtended
+  };    
+
   static bool checkFor2Gamma(const JPetEvent& event, JPetStatistics& stats,
                            bool saveHistos, double b2bSlotThetaDiff, double b2bTimeDiff);
   static bool checkFor3Gamma(const JPetEvent& event, JPetStatistics& stats, bool saveHistos);
@@ -38,7 +45,7 @@ public:
                              bool saveHistos, double deexTOTCutMin, double deexTOTCutMax);
   static bool checkForScatter(const JPetEvent& event, JPetStatistics& stats,
                               bool saveHistos, double scatterTOFTimeDiff);
-  static double calculateTOT(const JPetHit& hit);
+  static double calculateTOT(const JPetHit& hit, TOTCalculationType type);
   static double calculateDistance(const JPetHit& hit1, const JPetHit& hit2);
   static double calculateScatteringTime(const JPetHit& hit1, const JPetHit& hit2);
   static double calculateScatteringAngle(const JPetHit& hit1, const JPetHit& hit2);

--- a/LargeBarrelAnalysis/tests/EventCategorizerToolsTest.cpp
+++ b/LargeBarrelAnalysis/tests/EventCategorizerToolsTest.cpp
@@ -234,10 +234,10 @@ BOOST_AUTO_TEST_CASE(checkForPromptTest_checkTOTCalc) {
   hit2.setSignals(physSignal2A, physSignal2B);
   hit3.setSignals(physSignal3A, physSignal3B);
 
-  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit1), 0.0, kEpsilon);
-  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit2), 56.0,
+  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit1, EventCategorizerTools::TOTCalculationType::kStandard), 0.0, kEpsilon);
+  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit2, EventCategorizerTools::TOTCalculationType::kStandard), 56.0,
                       kEpsilon);
-  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit3), 560.0,
+  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit3, EventCategorizerTools::TOTCalculationType::kStandard), 560.0,
                       kEpsilon);
 
   JPetEvent event1;

--- a/LargeBarrelAnalysis/tests/EventCategorizerToolsTest.cpp
+++ b/LargeBarrelAnalysis/tests/EventCategorizerToolsTest.cpp
@@ -234,10 +234,10 @@ BOOST_AUTO_TEST_CASE(checkForPromptTest_checkTOTCalc) {
   hit2.setSignals(physSignal2A, physSignal2B);
   hit3.setSignals(physSignal3A, physSignal3B);
 
-  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit1, EventCategorizerTools::TOTCalculationType::kStandard), 0.0, kEpsilon);
-  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit2, EventCategorizerTools::TOTCalculationType::kStandard), 56.0,
+  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit1, EventCategorizerTools::TOTCalculationType::kSimplified), 0.0, kEpsilon);
+  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit2, EventCategorizerTools::TOTCalculationType::kSimplified), 56.0,
                       kEpsilon);
-  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit3, EventCategorizerTools::TOTCalculationType::kStandard), 560.0,
+  BOOST_REQUIRE_CLOSE(EventCategorizerTools::calculateTOT(hit3, EventCategorizerTools::TOTCalculationType::kSimplified), 560.0,
                       kEpsilon);
 
   JPetEvent event1;

--- a/PhysicAnalysis/EventCategorizerPhysics.cpp
+++ b/PhysicAnalysis/EventCategorizerPhysics.cpp
@@ -225,7 +225,7 @@ JPetEvent EventCategorizerPhysics::physicsAnalysis(vector<JPetHit> hits)
 
   for (unsigned i = 0; i < hits.size(); i++) {
     if (fabs(hits[i].getPosZ()) < fMaxZPos) {
-      double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kStandard);
+      double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kSimplified);
       if (fSaveControlHistos) {
         getStatistics().getHisto1D("AllHitTOT")->Fill(TOTofHit / 1000.);
       }

--- a/PhysicAnalysis/EventCategorizerPhysics.cpp
+++ b/PhysicAnalysis/EventCategorizerPhysics.cpp
@@ -225,7 +225,7 @@ JPetEvent EventCategorizerPhysics::physicsAnalysis(vector<JPetHit> hits)
 
   for (unsigned i = 0; i < hits.size(); i++) {
     if (fabs(hits[i].getPosZ()) < fMaxZPos) {
-      double TOTofHit = EventCategorizerTools::calculateTOT(hits[i]);
+      double TOTofHit = EventCategorizerTools::calculateTOT(hits[i], EventCategorizerTools::TOTCalculationType::kStandard);
       if (fSaveControlHistos) {
         getStatistics().getHisto1D("AllHitTOT")->Fill(TOTofHit / 1000.);
       }


### PR DESCRIPTION
Expanding TOT calculations to apply thresholds from the config file.
calculateTOT(const JPetHit& hit) changed to 
calculateTOT(const JPetHit& hit, TOTCalculationType type)
where type stands for different way of applying thresholds. 

Added definition of TOTCalculationType as 
enum TOTCalculationType
  {
    kStandard,
    kAdjustedToThresholds,
    kAdjustedToThresholdsExtended
  }; 

which stands for:
 - kStandard : TOT as a simple sum of TOT over all thresholds
 - kAdjustedToThresholds : TOT calculated as a rectangulars, thresholds used as a height of a rectangular
 - kAdjustedToThresholdsExtended : TOT as above with addition of triangles calculated between thresholds

weight parameter introduced to obtain similiar values of TOT for different TOTCalculationsType.
For 
kStandard : weight = 1
kAdjustedToThresholds and kAdjustedToThresholdsExtended : 
weight = threshold(i) - threshold(i-1)/threshold(1) // threshold(0) = 0
threshold(1) - first threshold used as a reference, because every signal has it and it is easier to implement that to use maximal difference between thresholds.