### PR TITLE
Updating JPetStatistic in calibration modules

### DIFF
--- a/InterThresholdCalibration/InterThresholdCalibration.cpp
+++ b/InterThresholdCalibration/InterThresholdCalibration.cpp
@@ -95,20 +95,24 @@ bool InterThresholdCalibration::init()
 //leading
 //histos for side A
         const char* histo_name_l_A = Form("timeDiffA_leading_layer_%d_slot_%d_thr_1%d", lay, sl, thre);
-        getStatistics().createHistogram( new TH1F(histo_name_l_A, histo_name_l_A, 200, -2., 2.));
+        getStatistics().createHistogramWithAxes( new TH1D(histo_name_l_A, histo_name_l_A, 200, -2., 2.),
+                                                            "Time difference A Leading [ns]", "Counts");
 
 //histos for side B
         const char* histo_name_l_B = Form("timeDiffB_leading_layer_%d_slot_%d_thr_1%d", lay, sl, thre);
-        getStatistics().createHistogram(new TH1F(histo_name_l_B, histo_name_l_B, 300, -3., 3.) );
+        getStatistics().createHistogramWithAxes( new TH1D(histo_name_l_B, histo_name_l_B, 300, -3., 3.),
+                                                            "Time difference B Leading reference detector [ns]", "Counts");
 
 //trailing
 //histos for side A
         const char* histo_name_t_A = Form("timeDiffA_trailing_layer_%d_slot_%d_thr_1%d", lay, sl, thre);
-        getStatistics().createHistogram( new TH1F(histo_name_t_A, histo_name_t_A, 200, -2., 2.));
+        getStatistics().createHistogramWithAxes( new TH1D(histo_name_t_A, histo_name_t_A, 200, -2., 2.),
+                                                            "Time difference A Trailing [ns]", "Counts");
 	
 //histos for side B
         const char* histo_name_t_B = Form("timeDiffB_trailing_layer_%d_slot_%d_thr_1%d", lay, sl, thre);
-        getStatistics().createHistogram(new TH1F(histo_name_t_B, histo_name_t_B, 300, -3., 3.));
+        getStatistics().createHistogramWithAxes( new TH1D(histo_name_t_B, histo_name_t_B, 300, -3., 3.),
+                                                            "Time difference B Trailing reference detector [ns]", "Counts");
       }
     }
   }
@@ -324,7 +328,7 @@ void InterThresholdCalibration::fillHistosForHit(const JPetHit& hit)
         thr_time_diff_A[thr] = lead_times_A[thr] / 1000 - lead_times_first_A / 1000;
 	
         char* histo_name_l_A = Form("timeDiffA_leading_layer_%d_slot_%d_thr_1%d", layer_number, slot_nr, thr);
-        getStatistics().getHisto1D(histo_name_l_A)->Fill(thr_time_diff_A[thr]);
+        getStatistics().fillHistogram(histo_name_l_A, thr_time_diff_A[thr]);
       }
     }
   }
@@ -343,7 +347,7 @@ void InterThresholdCalibration::fillHistosForHit(const JPetHit& hit)
         thr_time_diff_B[thr] = lead_times_B[thr] / 1000 - lead_times_first_B / 1000;
 
         char* histo_name_l_B = Form("timeDiffB_leading_layer_%d_slot_%d_thr_1%d", layer_number, slot_nr, thr);
-        getStatistics().getHisto1D(histo_name_l_B)->Fill(thr_time_diff_B[thr]);
+        getStatistics().fillHistogram(histo_name_l_B, thr_time_diff_B[thr]);
       }
     }
   }
@@ -363,8 +367,7 @@ void InterThresholdCalibration::fillHistosForHit(const JPetHit& hit)
         thr_time_diff_t_A[thr] = trail_times_A[thr] / 1000 - trail_times_first_A / 1000;
 
         char* histo_name_t_A = Form("timeDiffA_trailing_layer_%d_slot_%d_thr_1%d", layer_number, slot_nr, thr);
-        getStatistics().getHisto1D(histo_name_t_A)->Fill(thr_time_diff_t_A[thr]);
-
+        getStatistics().fillHistogram(histo_name_t_A, thr_time_diff_t_A[thr]);
       }
     }
   }
@@ -384,8 +387,7 @@ void InterThresholdCalibration::fillHistosForHit(const JPetHit& hit)
         thr_time_diff_t_B[thr] = trail_times_B[thr] / 1000 - trail_times_first_B / 1000;
 
         char* histo_name_t_B = Form("timeDiffB_trailing_layer_%d_slot_%d_thr_1%d", layer_number, slot_nr, thr);
-        getStatistics().getHisto1D(histo_name_t_B)->Fill(thr_time_diff_t_B[thr]);
-
+        getStatistics().fillHistogram(histo_name_t_B, thr_time_diff_t_B[thr]);
       }
     }
   }

--- a/TimeCalibration/TimeCalibration.cpp
+++ b/TimeCalibration/TimeCalibration.cpp
@@ -94,19 +94,23 @@ bool TimeCalibration::init()
 //		  const char * histo_name_l = formatUniqueSlotDescription(scin.at()->getBarrelSlot(), thr, "timeDiffAB_leading_");
 //
     const char* histo_name_l = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffAB_leading_", LayerToCalib, StripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_l, histo_name_l, 400, -20., 20.) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_l, histo_name_l, 400, -20., 20.),
+                                                            "Time difference AB Leading [ns]", "Counts");
     //
 //histograms for leading edge refference detector time difference
     const char* histo_name_Ref_l = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffRef_leading_", LayerToCalib, StripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_Ref_l, histo_name_Ref_l, 800, -80., 80.) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_Ref_l, histo_name_Ref_l, 800, -80., 80.),
+                                                            "Time difference AB Leading reference detector [ns]", "Counts");
     //
 //histos for trailing edge
     const char* histo_name_t = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffAB_trailing_", LayerToCalib, StripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_t, histo_name_t, 400, -20., 20.) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_t, histo_name_t, 400, -20., 20.),
+                                                            "Time difference AB Trailing [ns]", "Counts");
     //
 //histograms for leading edge refference detector time difference
     const char* histo_name_Ref_t = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffRef_trailing_", LayerToCalib, StripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_Ref_t, histo_name_Ref_t, 1000, -100., 100.) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_Ref_t, histo_name_Ref_t, 1000, -100., 100.),
+                                                            "Time difference AB Trailing reference detector [ns]", "Counts");
     //
   }
   INFO("#############");
@@ -381,7 +385,7 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
         // fill the appropriate histogram
         const char* histo_name_l = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffAB_leading_");
         //**const char * histo_name_l = Form("%slayer_%d_slot_%d_thr_%d","timeDiffAB_leading_",LayerToCalib,StripToCalib,thr);
-        getStatistics().getHisto1D(histo_name_l)->Fill( timeDiffAB_l);
+        getStatistics().fillHistogram(histo_name_l, timeDiffAB_l);
 //
 //take minimum time difference between Ref and Scint
         timeDiffLmin = 10000000000000.;
@@ -395,7 +399,7 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
         //**			const char * histo_name_Ref_l = Form("%slayer_%d_slot_%d_thr_%d","timeDiffRef_leading_",LayerToCalib,StripToCalib,thr);
         const char* histo_name_Ref_l = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffRef_leading_");
         if (timeDiffTmin < 100.) {
-          getStatistics().getHisto1D(histo_name_Ref_l)->Fill(timeDiffLmin);
+          getStatistics().fillHistogram(histo_name_Ref_l, timeDiffLmin);
         }
       }
     }
@@ -416,7 +420,7 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
         //fill the appropriate histogram
         const char* histo_name_t = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffAB_trailing_");
         //**const char * histo_name_t = Form("%slayer_%d_slot_%d_thr_%d","timeDiffAB_trailing_",LayerToCalib,StripToCalib,thr);
-        getStatistics().getHisto1D(histo_name_t)->Fill( timeDiffAB_t);
+        getStatistics().fillHistogram(histo_name_t, timeDiffAB_t);
 //
 //taken minimal time difference between Ref and Scint
         timeDiffTmin = 10000000000000.;
@@ -430,7 +434,7 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
         //**const char* histo_name_Ref_t = Form("%slayer_%d_slot_%d_thr_%d","timeDiffRef_trailing_",LayerToCalib,StripToCalib,thr);
         const char* histo_name_Ref_t = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffRef_trailing_");
         if (timeDiffTmin < 100.) {
-          getStatistics().getHisto1D(histo_name_Ref_t)->Fill(timeDiffTmin);
+          getStatistics().fillHistogram(histo_name_Ref_t, timeDiffTmin);
         }
       }
     }

--- a/TimeCalibration_iter/TimeCalibration.cpp
+++ b/TimeCalibration_iter/TimeCalibration.cpp
@@ -160,13 +160,17 @@ void TimeCalibration::createHistograms()
     }
  
     const char* histo_name_l = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffAB_leading_", fLayerToCalib, fStripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_l, histo_name_l,NbinABl,tABlmin,tABlmax) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_l, histo_name_l, NbinABl, tABlmin, tABlmax),
+                                                            "Time difference AB Leading [ns]", "Counts");
     const char* histo_name_Ref_l = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffRef_leading_", fLayerToCalib, fStripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_Ref_l, histo_name_Ref_l,NbinReffl,tRefflMin,tRefflMax) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_Ref_l, histo_name_Ref_l, NbinReffl, tRefflMin, tRefflMax),
+                                                            "Time difference AB Leading reference detector [ns]", "Counts");
     const char* histo_name_t = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffAB_trailing_", fLayerToCalib, fStripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_t, histo_name_t,NbinABt,tABtmin,tABtmax) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_t, histo_name_t, NbinABt, tABtmin, tABtmax),
+                                                            "Time difference AB Trailing [ns]", "Counts");
     const char* histo_name_Ref_t = Form("%slayer_%d_slot_%d_thr_%d", "timeDiffRef_trailing_", fLayerToCalib, fStripToCalib, thr);
-    getStatistics().createHistogram( new TH1F(histo_name_Ref_t, histo_name_Ref_t,NbinRefft,tRefftMin,tRefftMax) );
+    getStatistics().createHistogramWithAxes( new TH1D(histo_name_Ref_t, histo_name_Ref_t, NbinRefft, tRefftMin, tRefftMax),
+                                                            "Time difference AB Trailing reference detector [ns]", "Counts");
   }
 }
 
@@ -270,10 +274,7 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
       if ( lead_times_B.count(thr) > 0 ) {
         double timeDiffAB_l = (lead_times_B[thr] / 1000. + CBlCor[thr]) - (lead_times_A[thr] / 1000. + CAlCor[thr]);
         const char* histo_name_l = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffAB_leading_");
-        auto hist = getStatistics().getHisto1D(histo_name_l);
-        if (hist) {
-          getStatistics().getHisto1D(histo_name_l)->Fill( timeDiffAB_l);
-        }
+        getStatistics().fillHistogram(histo_name_l, timeDiffAB_l);
         timeDiffLmin = 10000000000000.;
         for (unsigned int i = 0; i < refTimesL.size(); i++) {
           double timeDiffHit_L = (lead_times_A[thr] / 1000. + CAlCor[thr]) + (lead_times_B[thr] / 1000. + CBlCor[thr]);
@@ -283,11 +284,8 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
           }
         }
         const char* histo_name_Ref_l = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffRef_leading_");
-        hist = getStatistics().getHisto1D(histo_name_Ref_l );
         if (timeDiffTmin < 100.) {
-          if (hist) {
-            getStatistics().getHisto1D(histo_name_Ref_l)->Fill(timeDiffLmin);
-          }
+          getStatistics().fillHistogram(histo_name_Ref_l, timeDiffLmin);
         }
       }
     }
@@ -297,10 +295,7 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
 
         double timeDiffAB_t = (trail_times_B[thr] / 1000. + CBtCor[thr]) - (trail_times_A[thr] / 1000. + CAtCor[thr]);
         const char* histo_name_t = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffAB_trailing_");
-        auto hist = getStatistics().getHisto1D(histo_name_t);
-        if (hist) {
-          getStatistics().getHisto1D(histo_name_t)->Fill( timeDiffAB_t);
-        }
+        getStatistics().fillHistogram(histo_name_t, timeDiffAB_t);
         timeDiffTmin = 10000000000000.;
         for (unsigned int i = 0; i < refTimesT.size(); i++) {
           double timeDiffHit_T = (trail_times_A[thr] / 1000. + CAtCor[thr]) + (trail_times_B[thr] / 1000. + CBtCor[thr]);
@@ -310,9 +305,8 @@ void TimeCalibration::fillHistosForHit(const JPetHit& hit, const std::vector<dou
           }
         }
         const char* histo_name_Ref_t = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffRef_trailing_");
-        hist = getStatistics().getHisto1D(histo_name_Ref_t);
         if (timeDiffTmin < 100.) {
-          getStatistics().getHisto1D(histo_name_Ref_t)->Fill(timeDiffTmin);
+          getStatistics().fillHistogram(histo_name_Ref_t, timeDiffTmin);
         }
       }
     }

--- a/VelocityCalibration/DeltaTFinder.cpp
+++ b/VelocityCalibration/DeltaTFinder.cpp
@@ -40,17 +40,19 @@ bool DeltaTFinder::init()
     for (auto & scin : getParamBank().getScintillators()) {
       for (int thr = 1; thr <= 4; thr++) {
         const char* histo_name = formatUniqueSlotDescription(scin.second->getBarrelSlot(), thr, "timeDiffAB_");
-        getStatistics().createHistogram( new TH1F(histo_name, histo_name, 400, -20., 20.) );
+        getStatistics().createHistogramWithAxes( new TH1D(histo_name, histo_name, 400, -19.95, 20.05),
+                                                 "Time difference AB [ns]", "Counts");
       }
     }
     // create histograms for time diffrerence vs slot ID
     for (auto & layer : getParamBank().getLayers()) {
       for (int thr = 1; thr <= 4; thr++) {
         const char* histo_name = Form("TimeDiffVsID_layer_%d_thr_%d", (int)fBarrelMap->getLayerNumber(*layer.second), thr);
-        const char* histo_titile = Form("%s;Slot ID; TimeDiffAB [ns]", histo_name);
+        const char* histo_title = Form("%s;Slot ID; TimeDiffAB [ns]", histo_name);
         int n_slots_in_layer = fBarrelMap->getSlotsCount(*layer.second);
-        getStatistics().createHistogram( new TH2F(histo_name, histo_titile, n_slots_in_layer, 0.5, n_slots_in_layer + 0.5,
-                                         120, -20., 20.) );
+        getStatistics().createHistogramWithAxes(new TH2D(histo_name, histo_title, 
+                                                         n_slots_in_layer, 0.5, n_slots_in_layer + 0.5, 120, -20., 20.), 
+                                                         "Slot ID", "Time difference AB [ns]");
       }
     }
   }
@@ -174,13 +176,12 @@ void DeltaTFinder::fillHistosForHit(const JPetHit& hit)
       timeDiffAB /= 1000.; // we want the plots in ns instead of ps
       // fill the appropriate histogram
       const char* histo_name = formatUniqueSlotDescription(hit.getBarrelSlot(), thr, "timeDiffAB_");
-      getStatistics().getHisto1D(histo_name)->Fill( timeDiffAB );
+      getStatistics().fillHistogram(histo_name, timeDiffAB);
 
       // fill the timeDiffAB vs slot ID histogram
       int layer_number = fBarrelMap->getLayerNumber( hit.getBarrelSlot().getLayer() );
       int slot_number = fBarrelMap->getSlotNumber( hit.getBarrelSlot() );
-      getStatistics().getHisto2D(Form("TimeDiffVsID_layer_%d_thr_%d", layer_number, thr))->Fill( slot_number,
-          timeDiffAB);
+      getStatistics().fillHistogram(Form("TimeDiffVsID_layer_%d_thr_%d", layer_number, thr), slot_number, timeDiffAB);     
     }
   }
 }


### PR DESCRIPTION
I continue to update new methods of JPETStatistic creation and filling histogram.
This step: Calibration modules
What`s left: ImageReconstruction, but it uses more general getObject methods, so maybe it is not applicable here