### PR TITLE
Added scripts for parallel analysis

### DIFF
--- a/scripts/parallel_analysis.py
+++ b/scripts/parallel_analysis.py
@@ -5,7 +5,9 @@ from os import listdir, system, path
 from sys import exit
 from fnmatch import filter
 import argparse
+from sys import exit
 
+ALLOWED_TYPES = ["root", "mcGeant", "hld", "zip", "scope"]
 
 def main():
     parser = argparse.ArgumentParser(
@@ -47,15 +49,9 @@ def main():
             "\033[93m" + "Module tqdm for Python3 not found. Running without progress bar" + "\033[0m")
         progress_bar = False
 
-    run_id_setup = run_id
 
-    run6_mapping = {"61": "6A",
-                    "62": "6B",
-                    "63": "6C",
-                    "64": "6D"}
+    run_id_setup = get_run_id_setup_mapping(run_id)
 
-    if run_id[0] == "6":
-        run_id_setup = run6_mapping[run_id]
 
     if threads > 20:
         print(
@@ -76,14 +72,13 @@ def main():
                 "\033[31m" + "Specified output drectory des not exist. Please check spelling or create a directory." + "\033[0m")
             exit()
 
-        if output_directory[-1] is not "/":
+        if output_directory[-1] != "/":
             output_directory += "/"
 
     if file_type != "root":
-        allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
-        if file_type not in allowed_types:
+        if file_type not in ALLOWED_TYPES:
             print("\033[31m" + "Specified file type is not valid. Please check if it's one of the following: \n{}".format(
-                ", ".join(allowed_types)) + "\033[0m")
+                ", ".join(ALLOWED_TYPES)) + "\033[0m")
             exit()
 
     files_needed_for_analysis = [
@@ -114,7 +109,7 @@ def main():
                 executable, filename, run_id, run_id_setup, output_directory))
 
     else:
-        def run_analysis_parallel(i):
+        def run_analysis_parallel(filename):
             system("./{} -t root -f {} -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json".format(
                 executable, filename, run_id, run_id_setup))
 
@@ -136,6 +131,18 @@ def main():
 
     pool.close()
     pool.join()
+
+
+def get_run_id_setup_mapping(run_id):
+    run6_mapping = {"61": "6A",
+                    "62": "6B",
+                    "63": "6C",
+                    "64": "6D"}
+
+    if run_id[0] == "6":
+        run_id_setup = run6_mapping[run_id]
+    else:
+        run_id_setup = run_id
 
 
 if __name__ == "__main__":

--- a/scripts/parallel_purge.py
+++ b/scripts/parallel_purge.py
@@ -5,19 +5,6 @@ import argparse
 from subprocess import Popen, PIPE
 from multiprocessing.dummy import Pool as PoolThread
 
-try:
-    from termcolor import colored
-except ImportError:
-    print("\033[93m" + "Please instal module termcolor for Python3. \n \
-run command: sudo apt-get install python3-termcolor \n \
-or equivalent on your operating system" + "\033[0m")
-try:
-    import tqdm
-except ImportError:
-    print("\033[93m" + "Please instal module tqdm for Python3. \n \
-run command: sudo apt-get install python3-tqdm \n \
-or equivalent on your operating system" + "\033[0m")
-
 
 def main():
     parser = argparse.ArgumentParser(
@@ -35,20 +22,29 @@ def main():
     progress_bar = args["progress_bar"]
     threads = args["number_of_threads"]
 
+    try:
+        import tqdm
+    except ImportError:
+        print(
+            "\033[93m" + "Module tqdm for Python3 not found. Running without progress bar" + "\033[0m")
+        progress_bar = False
+
     if threads > 20:
-        print(colored(
-            "Try not to use more than 20 threads, let others also run analysis.", "red", attrs=["underline"]))
+        print("\033[31m" + "Try not to use more than 20 threads, let others also run analysis." +
+              "\033[0m", attrs=["underline"])
         exit()
 
     if not path.isdir(input_directory):
-        print(colored(
-            "Specified input drectory des not exist. Please check spelling.", "red"))
+        print(
+            "\033[31m" + "Specified input drectory des not exist. Please check spelling." + "\033[0m")
         exit()
 
     if input_directory[-1] != "/":
         input_directory += "/"
 
     list_of_files = filter(listdir(input_directory), "*.root")
+
+    print("\033[32m" + "All checks passed, purging now." + "\033[0m")
 
     pool = PoolThread(threads)
 

--- a/scripts/parallel_purge.py
+++ b/scripts/parallel_purge.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from fnmatch import filter
-from os import system, path, listdir
+from os import path, listdir, popen
 import argparse
 
 from multiprocessing.dummy import Pool as PoolThread
@@ -53,7 +53,7 @@ def main():
     pool = PoolThread(threads)
 
     def run_macro_parallel(file):
-        system("root -l -b -q \"purge.C(\\\"{}{}\\\")\"".format(input_directory, file))
+        popen("root -l -b -q \"purge.C(\\\"{}{}\\\")\"".format(input_directory, file))
 
     if progress_bar:
         for _ in tqdm.tqdm(pool.imap(run_macro_parallel, list_of_files), total=len(list_of_files)):

--- a/scripts/parallel_purge.py
+++ b/scripts/parallel_purge.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from fnmatch import filter
+from termcolor import colored
+import tqdm
+import os
+import sys
+import subprocess
+
+import argparse
+
+from multiprocessing.dummy import Pool as PoolThread
+
+parser = argparse.ArgumentParser(
+    "Python script to purge root files in parallel")
+parser.add_argument("directory", type=str,
+
+                    help="Directory in which you want to purge files.")
+parser.add_argument("-n", "--number-of-threads", required=False, default=20, type=int,
+                    help="Number of threads to run simultaneously")
+
+args = vars(parser.parse_args())
+# root macro run format
+# root -l "macro.C+(arg1,arg2,arg3,...,argn)"
+
+
+def argConversion(arg):
+    if type(arg) in [float, int]:
+        return str(arg)
+    elif type(arg) in [str]:
+        return '"' + arg + '"'
+    else:
+        return '"' + str(arg) + '"'
+
+
+def argConnection(arglist=[]):
+    if not (arglist is [] or arglist is None):
+        shellargv = list(arglist)
+        arglist_conv = list()
+        for arg in arglist:
+            arglist_conv.append(argConversion(arg))
+        return '(' + ','.join(arglist_conv) + ')'
+    else:
+        return ''
+
+
+def runMacro(macroName, arglist=None, splash=False, interprete=False, batch=True):
+    shellCommand = ['root']
+    if interprete is False:
+        shellCommand.append("-q")
+    if splash is False:
+        shellCommand.append("-l")
+    if batch is True:
+        shellCommand.append("-b")
+    shellCommand.append(macroName + argConnection(arglist))
+    print("Run Macro", shellCommand)
+    a = subprocess.Popen(shellCommand)
+    return a
+
+
+def run_macro_parallel(file):
+    runMacro('purge.C', arglist=[file])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        "Python script to purge root files in parallel")
+    parser.add_argument("directory", type=str,
+                        help="Directory in which you want to purge files.")
+    parser.add_argument("-p", "--progress-bar", action="store_false", required=False,
+                        help="Using this option turns progress bar off")
+    parser.add_argument("-n", "--number-of-threads", required=False, default=20, type=int,
+                        help="Number of threads to run simultaneously")
+
+    args = vars(parser.parse_args())
+
+    input_directory = args["directory"]
+    progress_bar = args["progress_bar"]
+    threads = args["number_of_threads"]
+
+    if threads > 20:
+        print(colored(
+            "Try not to use more than 20 threads, let others also run analysis.", "red", attrs=["underline"]))
+        exit()
+
+    if not os.path.isdir(input_directory):
+        print(colored(
+            "Specified input drectory des not exist. Please check spelling.", "red"))
+        exit()
+
+    list_of_files = filter(os.listdir(input_directory), "*.root")
+
+    pool = PoolThread(threads)
+
+    if progress_bar:
+        for _ in tqdm.tqdm(pool.imap(run_macro_parallel, list_of_files), total=len(list_of_files)):
+            pass
+    else:
+        result = pool.map(run_macro_parallel, list_of_files)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parallel_purge.py
+++ b/scripts/parallel_purge.py
@@ -2,7 +2,7 @@
 from fnmatch import filter
 from os import path, listdir, popen
 import argparse
-
+from subprocess import Popen, PIPE
 from multiprocessing.dummy import Pool as PoolThread
 
 try:
@@ -53,7 +53,8 @@ def main():
     pool = PoolThread(threads)
 
     def run_macro_parallel(file):
-        popen("root -l -b -q \"purge.C(\\\"{}{}\\\")\"".format(input_directory, file))
+        Popen("root -l -b -q \"purge.C(\\\"{}{}\\\")\"".format(input_directory,
+                                                               file), shell=True, stdout=PIPE).wait()
 
     if progress_bar:
         for _ in tqdm.tqdm(pool.imap(run_macro_parallel, list_of_files), total=len(list_of_files)):
@@ -61,8 +62,8 @@ def main():
     else:
         result = pool.map(run_macro_parallel, list_of_files)
 
-    pool.close()
     pool.join()
+    pool.close()
 
 
 if __name__ == "__main__":

--- a/scripts/parallel_purge.py
+++ b/scripts/parallel_purge.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 from fnmatch import filter
-from os import path, listdir, popen
+from os import path, listdir
 import argparse
 from subprocess import Popen, PIPE
 from multiprocessing.dummy import Pool as PoolThread
-
+from sys import exit
 
 def main():
     parser = argparse.ArgumentParser(
@@ -31,7 +31,7 @@ def main():
 
     if threads > 20:
         print("\033[31m" + "Try not to use more than 20 threads, let others also run analysis." +
-              "\033[0m", attrs=["underline"])
+              "\033[0m")
         exit()
 
     if not path.isdir(input_directory):
@@ -56,7 +56,7 @@ def main():
         for _ in tqdm.tqdm(pool.imap(run_macro_parallel, list_of_files), total=len(list_of_files)):
             pass
     else:
-        result = pool.map(run_macro_parallel, list_of_files)
+        pool.map(run_macro_parallel, list_of_files)
 
     pool.join()
     pool.close()

--- a/scripts/parallel_purge.py
+++ b/scripts/parallel_purge.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
 from fnmatch import filter
-from termcolor import colored
-import tqdm
 import os
 import sys
 import subprocess
-
 import argparse
+
+try:
+    from termcolor import colored
+except ImportError:
+    print("\033[93m" + "Please instal module termcolor for Python3. \n \
+run command: sudo apt-get install python3-termcolor \n \
+or equivalent on your operating system" + "\033[0m")
+try:
+    import tqdm
+except ImportError:
+    print("\033[93m" + "Please instal module tqdm for Python3. \n \
+run command: sudo apt-get install python3-tqdm \n \
+or equivalent on your operating system" + "\033[0m")
 
 from multiprocessing.dummy import Pool as PoolThread
 
-parser = argparse.ArgumentParser(
-    "Python script to purge root files in parallel")
-parser.add_argument("directory", type=str,
-
-                    help="Directory in which you want to purge files.")
-parser.add_argument("-n", "--number-of-threads", required=False, default=20, type=int,
-                    help="Number of threads to run simultaneously")
-
-args = vars(parser.parse_args())
 # root macro run format
 # root -l "macro.C+(arg1,arg2,arg3,...,argn)"
 

--- a/scripts/purge.C
+++ b/scripts/purge.C
@@ -1,0 +1,19 @@
+#include <TFile.h>
+#include <TClass.h>
+#include <TKey.h>
+#include <TROOT.h>
+
+void purge(const char* filename){
+  TFile* f = new TFile(filename, "UPDATE");
+
+  TIter next(f->GetListOfKeys());
+  TKey *key;
+  while ((key = (TKey*)next())) {
+    TClass *cl = gROOT->GetClass(key->GetClassName());
+    if(!cl->InheritsFrom("TDirectory")){
+      key->Delete();
+    }
+  }
+
+  f->Close();
+}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+tqdm==4.19.5
+termcolor==1.1.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,1 @@
 tqdm==4.19.5
-termcolor==1.1.0

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -53,15 +53,13 @@ def main():
 
     run_id_setup = run_id
 
+    run6_mapping = {"61": "6A",
+                    "62": "6B",
+                    "63": "6C",
+                    "64": "6D"}
+
     if run_id[0] == "6":
-        if run_id[1] == "1":
-            run_id_setup = "6A"
-        elif run_id[1] == "2":
-            run_id_setup = "6B"
-        elif run_id[1] == "3":
-            run_id_setup = "6C"
-        elif run_id[1] == "4":
-            run_id_setup = "6D"
+        run_id_setup = run6_mapping[run_id]
 
     if threads > 20:
         print(colored("Try not to use more than 20 threads, let others also run analysis.",

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -4,102 +4,130 @@ from multiprocessing.dummy import Pool as PoolThread
 from os import listdir, system, path
 from sys import exit
 from fnmatch import filter
-from termcolor import colored
-import tqdm
 import argparse
 
-
-parser = argparse.ArgumentParser("Python script to analyze files in parallel")
-parser.add_argument("executable", type=str,
-                    help="Executable you want to run")
-parser.add_argument("-i", "--input", required=True, type=str,
-                    help="Path to the directory you want to analyze")
-parser.add_argument("-r", "--run-id", required=True, type=str,
-                    help="Number of run which you are analyzing")
-
-parser.add_argument("-t", "--type", required=False, type=str, default="root",
-                    help="Path to the directory you want to analyze")
-parser.add_argument("-o", "--output", required=False,
-                    help="Path to the output directory in which you want to save analyzed files")
-parser.add_argument("-p", "--progress-bar", action="store_false",
-                    help="Using this option turns progress bar off")
-parser.add_argument("-n", "--number-of-threads", required=False, default=20, type=int,
-                    help="Number of threads to run simultaneously")
-
-args = vars(parser.parse_args())
-
-executable = args["executable"]
-input_directory = args["input"]
-output_directory = args["output"]
-progress_bar = args["progress_bar"]
-run_id = args["run_id"]
-file_type = args["type"]
-threads = args["number_of_threads"]
-
-if threads > 20:
-    print(colored("Try not to use more than 20 threads, let others also run analysis.",
-                  "red", attrs=["underline"]))
-
-if not path.isdir(input_directory):
-    print(colored("Specified input drectory des not exist. Please check spelling.", "red"))
+try:
+    from termcolor import colored
+except ImportError:
+    print("\033[93m" + "Please instal module termcolor for Python3. \n \
+run command: sudo apt-get install python3-termcolor \n \
+or equivalent on your operating system" + "\033[0m")
+    exit()
+try:
+    import tqdm
+except ImportError:
+    print("\033[93m" + "Please instal module tqdm for Python3. \n \
+run command: sudo apt-get install python3-tqdm \n \
+or equivalent on your operating system" + "\033[0m")
     exit()
 
-if input_directory[-1] != "/":
-    input_directory += "/"
 
+def main():
+    parser = argparse.ArgumentParser(
+        "Python script to analyze files in parallel")
+    parser.add_argument("executable", type=str,
+                        help="Executable you want to run")
+    parser.add_argument("-i", "--input", required=True, type=str,
+                        help="Path to the directory you want to analyze")
+    parser.add_argument("-r", "--run-id", required=True, type=str,
+                        help="Number of run which you are analyzing")
 
-if output_directory is not None:
-    if not path.isdir(output_directory):
+    parser.add_argument("-t", "--type", required=False, type=str, default="root",
+                        help="Path to the directory you want to analyze")
+    parser.add_argument("-o", "--output", required=False,
+                        help="Path to the output directory in which you want to save analyzed files")
+    parser.add_argument("-p", "--progress-bar", action="store_false",
+                        help="Using this option turns progress bar off")
+    parser.add_argument("-n", "--number-of-threads", required=False, default=20, type=int,
+                        help="Number of threads to run simultaneously")
+
+    args = vars(parser.parse_args())
+
+    executable = args["executable"]
+    input_directory = args["input"]
+    output_directory = args["output"]
+    progress_bar = args["progress_bar"]
+    run_id = args["run_id"]
+    file_type = args["type"]
+    threads = args["number_of_threads"]
+
+    run_id_setup = run_id
+
+    if run_id[0] == "6":
+        if run_id[1] == "1":
+            run_id_setup = "6A"
+        elif run_id[1] == "2":
+            run_id_setup = "6B"
+        elif run_id[1] == "3":
+            run_id_setup = "6C"
+        elif run_id[1] == "4":
+            run_id_setup = "6D"
+
+    if threads > 20:
+        print(colored("Try not to use more than 20 threads, let others also run analysis.",
+                      "red", attrs=["underline"]))
+
+    if not path.isdir(input_directory):
         print(colored(
-            "Specified output drectory des not exist. Please check spelling or create a directory.", "red"))
+            "Specified input drectory des not exist. Please check spelling.", "red"))
         exit()
 
-    if output_directory[-1] is not "/":
-        output_directory += "/"
+    if input_directory[-1] != "/":
+        input_directory += "/"
 
+    if output_directory is not None:
+        if not path.isdir(output_directory):
+            print(colored(
+                "Specified output drectory des not exist. Please check spelling or create a directory.", "red"))
+            exit()
 
-if file_type != "root":
-    allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
-    if file_type not in allowed_types:
-        print(colored("Specified file type is not valid. Please check if it's one of the following: {}".format(
-            ", ".join(allowed_types)), "red"))
+        if output_directory[-1] is not "/":
+            output_directory += "/"
+
+    if file_type != "root":
+        allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
+        if file_type not in allowed_types:
+            print(colored("Specified file type is not valid. Please check if it's one of the following: {}".format(
+                ", ".join(allowed_types)), "red"))
+            exit()
+
+    files_needed_for_analysis = [
+        "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id)]
+    needed_files_present = True
+    for file in files_needed_for_analysis:
+        if not path.isfile(file):
+            print(
+                colored("File {} does not exist in current directory.".format(file), "red"))
+            needed_files_present = False
+
+    if not needed_files_present:
         exit()
 
+    if output_directory is not None:
+        def run_analysis_parallel(filename):
+            print("./{} -t root -f {}{} -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json -o {}".format(
+                executable, input_directory, filename, run_id, run_id_setup, output_directory))
 
-files_needed_for_analysis = [
-    "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id)]
-needed_files_present = True
-for file in files_needed_for_analysis:
-    if not path.isfile(file):
-        print(colored("File {} does not exist in current directory.".format(file), "red"))
-        needed_files_present = False
+    else:
+        def run_analysis_parallel(i):
+            print("./{} -t root -f {}{} -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json".format(
+                executable, input_directory, filename, run_id, run_id_setup))
 
-if not needed_files_present:
-    exit()
+    list_of_files = listdir(input_directory)
 
-if output_directory is not None:
-    def run_analysis_parallel(i):
-        system("./{} -t root -f {}".format(executable, input_directory) + i +
-               " -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json \
--o {}".format(run_id, run_id, output_directory))
+    print(colored("All checks passed, running analysis now.", "green"))
 
-else:
-    def run_analysis_parallel(i):
-        system("./{} -t root -f {}".format(executable, input_directory) + i +
-               " -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json".format(run_id, run_id))
+    pool = PoolThread(threads)
 
+    if progress_bar:
+        for _ in tqdm.tqdm(pool.imap(run_analysis_parallel, list_of_files), total=len(list_of_files)):
+            pass
+    else:
+        results = pool.map(run_analysis_parallel, list_of_files)
 
-list_of_files = listdir(input_directory)
-
-print(colored("All checks passed, running analysis now.", "green"))
-pool = PoolThread(threads)
-
-if progress_bar:
-    for _ in tqdm.tqdm(pool.imap(run_analysis_parallel, list_of_files), total=len(list_of_files)):
-        pass
-else:
-    results = pool.map(run_analysis_parallel, list_of_files)
+    pool.close()
+    pool.join()
 
 
-pool.close()
-pool.join()
+if __name__ == "__main__":
+    main()

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -32,6 +32,9 @@ def main():
     parser.add_argument("-r", "--run-id", required=True, type=str,
                         help="Number of run which you are analyzing")
 
+    parser.add_argument("-e", "--extension", required=False, type=str, default="*",
+                        help="Extention of files you want to analyze")
+
     parser.add_argument("-t", "--type", required=False, type=str, default="root",
                         help="Path to the directory you want to analyze")
     parser.add_argument("-o", "--output", required=False,
@@ -50,6 +53,7 @@ def main():
     run_id = args["run_id"]
     file_type = args["type"]
     threads = args["number_of_threads"]
+    extension = args["extension"]
 
     run_id_setup = run_id
 
@@ -85,7 +89,7 @@ def main():
     if file_type != "root":
         allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
         if file_type not in allowed_types:
-            print(colored("Specified file type is not valid. Please check if it's one of the following: {}".format(
+            print(colored("Specified file type is not valid. Please check if it's one of the following: \n{}".format(
                 ", ".join(allowed_types)), "red"))
             exit()
 
@@ -103,6 +107,14 @@ def main():
     if not needed_files_present:
         exit()
 
+    supported_extensions = ["*", "hld", "hld.root", "tslot.calib.root", "raw.sig.root",
+                            "phys.sig.root", "hits.root", "unk.evt.root", "cat.evt.root"]
+
+    if extension not in supported_extensions:
+        print(colored("Specified file extension is not valid. Please check if it's one of the following: \n{}".format(
+            ", ".join(supported_extensions[1:])), "red"))
+        exit()
+
     if output_directory is not None:
         def run_analysis_parallel(filename):
             print("./{} -t root -f {}{} -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json -o {}".format(
@@ -113,7 +125,7 @@ def main():
             print("./{} -t root -f {}{} -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json".format(
                 executable, input_directory, filename, run_id, run_id_setup))
 
-    list_of_files = listdir(input_directory)
+    list_of_files = filter(listdir(input_directory), "*.{}".format(extension))
 
     print(colored("All checks passed, running analysis now.", "green"))
 

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -92,8 +92,10 @@ def main():
             exit()
 
     files_needed_for_analysis = [
-        "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id)]
+        "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id_setup)]
+
     needed_files_present = True
+
     for file in files_needed_for_analysis:
         if not path.isfile(file):
             print(

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -58,7 +58,8 @@ def main():
         run_id_setup = run6_mapping[run_id]
 
     if threads > 20:
-        print("\033[31m" + "Try not to use more than 20 threads, let others also run analysis." + "\033[0m", attrs=["underline"]))
+        print(
+            "\033[31m" + "Try not to use more than 20 threads, let others also run analysis." + "\033[0m")
 
     if not path.isdir(input_directory):
         print(
@@ -71,20 +72,20 @@ def main():
     if output_directory is not None:
         if not path.isdir(output_directory):
             print(
-                "\033[31m" + "Specified output drectory des not exist. Please check spelling or create a directory.", + "\033[0m")
+                "\033[31m" + "Specified output drectory des not exist. Please check spelling or create a directory." + "\033[0m")
             exit()
 
         if output_directory[-1] is not "/":
             output_directory += "/"
 
     if file_type != "root":
-        allowed_types=["root", "mcGeant", "hld", "zip", "scope"]
+        allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
         if file_type not in allowed_types:
             print("\033[31m" + "Specified file type is not valid. Please check if it's one of the following: \n{}".format(
                 ", ".join(allowed_types)) + "\033[0m")
             exit()
 
-    files_needed_for_analysis=[
+    files_needed_for_analysis = [
         "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id_setup)]
 
     needed_files_present = True
@@ -92,13 +93,13 @@ def main():
     for file in files_needed_for_analysis:
         if not path.isfile(file):
             print(
-                "\033[31m" + "File {} does not exist in current directory.".format(file), + "\033[0m")
-            needed_files_present=False
+                "\033[31m" + "File {} does not exist in current directory.".format(file) + "\033[0m")
+            needed_files_present = False
 
     if not needed_files_present:
         exit()
 
-    supported_extensions=["*", "hld", "hld.root", "tslot.calib.root", "raw.sig.root",
+    supported_extensions = ["*", "hld", "hld.root", "tslot.calib.root", "raw.sig.root",
                             "phys.sig.root", "hits.root", "unk.evt.root", "cat.evt.root"]
 
     if extension not in supported_extensions:

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -6,21 +6,6 @@ from sys import exit
 from fnmatch import filter
 import argparse
 
-try:
-    from termcolor import colored
-except ImportError:
-    print("\033[93m" + "Please instal module termcolor for Python3. \n \
-run command: sudo apt-get install python3-termcolor \n \
-or equivalent on your operating system" + "\033[0m")
-    exit()
-try:
-    import tqdm
-except ImportError:
-    print("\033[93m" + "Please instal module tqdm for Python3. \n \
-run command: sudo apt-get install python3-tqdm \n \
-or equivalent on your operating system" + "\033[0m")
-    exit()
-
 
 def main():
     parser = argparse.ArgumentParser(
@@ -55,6 +40,13 @@ def main():
     threads = args["number_of_threads"]
     extension = args["extension"]
 
+    try:
+        import tqdm
+    except ImportError:
+        print(
+            "\033[93m" + "Module tqdm for Python3 not found. Running without progress bar" + "\033[0m")
+        progress_bar = False
+
     run_id_setup = run_id
 
     run6_mapping = {"61": "6A",
@@ -66,12 +58,11 @@ def main():
         run_id_setup = run6_mapping[run_id]
 
     if threads > 20:
-        print(colored("Try not to use more than 20 threads, let others also run analysis.",
-                      "red", attrs=["underline"]))
+        print("\033[31m" + "Try not to use more than 20 threads, let others also run analysis." + "\033[0m", attrs=["underline"]))
 
     if not path.isdir(input_directory):
-        print(colored(
-            "Specified input drectory des not exist. Please check spelling.", "red"))
+        print(
+            "\033[31m" + "Specified input drectory des not exist. Please check spelling." + "\033[0m")
         exit()
 
     if input_directory[-1] != "/":
@@ -79,21 +70,21 @@ def main():
 
     if output_directory is not None:
         if not path.isdir(output_directory):
-            print(colored(
-                "Specified output drectory des not exist. Please check spelling or create a directory.", "red"))
+            print(
+                "\033[31m" + "Specified output drectory des not exist. Please check spelling or create a directory.", + "\033[0m")
             exit()
 
         if output_directory[-1] is not "/":
             output_directory += "/"
 
     if file_type != "root":
-        allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
+        allowed_types=["root", "mcGeant", "hld", "zip", "scope"]
         if file_type not in allowed_types:
-            print(colored("Specified file type is not valid. Please check if it's one of the following: \n{}".format(
-                ", ".join(allowed_types)), "red"))
+            print("\033[31m" + "Specified file type is not valid. Please check if it's one of the following: \n{}".format(
+                ", ".join(allowed_types)) + "\033[0m")
             exit()
 
-    files_needed_for_analysis = [
+    files_needed_for_analysis=[
         "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id_setup)]
 
     needed_files_present = True
@@ -101,18 +92,18 @@ def main():
     for file in files_needed_for_analysis:
         if not path.isfile(file):
             print(
-                colored("File {} does not exist in current directory.".format(file), "red"))
-            needed_files_present = False
+                "\033[31m" + "File {} does not exist in current directory.".format(file), + "\033[0m")
+            needed_files_present=False
 
     if not needed_files_present:
         exit()
 
-    supported_extensions = ["*", "hld", "hld.root", "tslot.calib.root", "raw.sig.root",
+    supported_extensions=["*", "hld", "hld.root", "tslot.calib.root", "raw.sig.root",
                             "phys.sig.root", "hits.root", "unk.evt.root", "cat.evt.root"]
 
     if extension not in supported_extensions:
-        print(colored("Specified file extension is not valid. Please check if it's one of the following: \n{}".format(
-            ", ".join(supported_extensions[1:])), "red"))
+        print("\033[31m" + "Specified file extension is not valid. Please check if it's one of the following: \n{}".format(
+            ", ".join(supported_extensions[1:])) + "\033[0m")
         exit()
 
     if output_directory is not None:
@@ -127,7 +118,7 @@ def main():
 
     list_of_files = filter(listdir(input_directory), "*.{}".format(extension))
 
-    print(colored("All checks passed, running analysis now.", "green"))
+    print("\033[32m" + "All checks passed, running analysis now." + "\033[0m")
 
     pool = PoolThread(threads)
 

--- a/scripts/run_parallel_analysis.py
+++ b/scripts/run_parallel_analysis.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+from multiprocessing.dummy import Pool as PoolThread
+from os import listdir, system, path
+from sys import exit
+from fnmatch import filter
+from termcolor import colored
+import tqdm
+import argparse
+
+
+parser = argparse.ArgumentParser("Python script to analyze files in parallel")
+parser.add_argument("executable", type=str,
+                    help="Executable you want to run")
+parser.add_argument("-i", "--input", required=True, type=str,
+                    help="Path to the directory you want to analyze")
+parser.add_argument("-r", "--run-id", required=True, type=str,
+                    help="Number of run which you are analyzing")
+
+parser.add_argument("-t", "--type", required=False, type=str, default="root",
+                    help="Path to the directory you want to analyze")
+parser.add_argument("-o", "--output", required=False,
+                    help="Path to the output directory in which you want to save analyzed files")
+parser.add_argument("-p", "--progress-bar", action="store_false",
+                    help="Using this option turns progress bar off")
+parser.add_argument("-n", "--number-of-threads", required=False, default=20, type=int,
+                    help="Number of threads to run simultaneously")
+
+args = vars(parser.parse_args())
+
+executable = args["executable"]
+input_directory = args["input"]
+output_directory = args["output"]
+progress_bar = args["progress_bar"]
+run_id = args["run_id"]
+file_type = args["type"]
+threads = args["number_of_threads"]
+
+if threads > 20:
+    print(colored("Try not to use more than 20 threads, let others also run analysis.",
+                  "red", attrs=["underline"]))
+
+if not path.isdir(input_directory):
+    print(colored("Specified input drectory des not exist. Please check spelling.", "red"))
+    exit()
+
+if input_directory[-1] != "/":
+    input_directory += "/"
+
+
+if output_directory is not None:
+    if not path.isdir(output_directory):
+        print(colored(
+            "Specified output drectory des not exist. Please check spelling or create a directory.", "red"))
+        exit()
+
+    if output_directory[-1] is not "/":
+        output_directory += "/"
+
+
+if file_type != "root":
+    allowed_types = ["root", "mcGeant", "hld", "zip", "scope"]
+    if file_type not in allowed_types:
+        print(colored("Specified file type is not valid. Please check if it's one of the following: {}".format(
+            ", ".join(allowed_types)), "red"))
+        exit()
+
+
+files_needed_for_analysis = [
+    "userParams.json", "conf_trb3.xml", "detectorSetupRun{}.json".format(run_id)]
+needed_files_present = True
+for file in files_needed_for_analysis:
+    if not path.isfile(file):
+        print(colored("File {} does not exist in current directory.".format(file), "red"))
+        needed_files_present = False
+
+if not needed_files_present:
+    exit()
+
+if output_directory is not None:
+    def run_analysis_parallel(i):
+        system("./{} -t root -f {}".format(executable, input_directory) + i +
+               " -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json \
+-o {}".format(run_id, run_id, output_directory))
+
+else:
+    def run_analysis_parallel(i):
+        system("./{} -t root -f {}".format(executable, input_directory) + i +
+               " -p conf_trb3.xml -u userParams.json -i {} -l detectorSetupRun{}.json".format(run_id, run_id))
+
+
+list_of_files = listdir(input_directory)
+
+print(colored("All checks passed, running analysis now.", "green"))
+pool = PoolThread(threads)
+
+if progress_bar:
+    for _ in tqdm.tqdm(pool.imap(run_analysis_parallel, list_of_files), total=len(list_of_files)):
+        pass
+else:
+    results = pool.map(run_analysis_parallel, list_of_files)
+
+
+pool.close()
+pool.join()


### PR DESCRIPTION
I added python script that runs analysis in parallel. It requires 2 packages that are not instaled by default:
tqdm and termcolor
both of which should be on the server.
First script runs any framework-examples executable and analyzes all files in a specified directory.

Second script purges all root from parmbanks files in specified directory by running purge.C script made by Alek.

In case ./script.py -h is not enough I will prepare readme with detailed description of how to run them