### PR TITLE
Extend the MCGeantAnalysis example

### DIFF
--- a/MCGeantAnalysis/CMakeLists.txt
+++ b/MCGeantAnalysis/CMakeLists.txt
@@ -34,18 +34,16 @@ project(${projectName} CXX)
 
 set(use_modules_from ../LargeBarrelAnalysis)
 set(HEADERS ${use_modules_from}/HitFinder.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/EventAnalyzer.h
             ${use_modules_from}/HitFinderTools.h
             ${use_modules_from}/EventFinder.h
-            ${use_modules_from}/EventCategorizer.h
-            ${use_modules_from}/EventCategorizerTools.h
             ${use_modules_from}/UniversalFileLoader.h)
-
+          
 set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/EventAnalyzer.cpp
             ${use_modules_from}/HitFinder.cpp
             ${use_modules_from}/HitFinderTools.cpp
             ${use_modules_from}/EventFinder.cpp
-            ${use_modules_from}/EventCategorizer.cpp
-            ${use_modules_from}/EventCategorizerTools.cpp
             ${use_modules_from}/UniversalFileLoader.cpp)
 
 add_executable(${projectBinary} ${SOURCES} ${HEADERS})

--- a/MCGeantAnalysis/EventAnalyzer.cpp
+++ b/MCGeantAnalysis/EventAnalyzer.cpp
@@ -29,11 +29,11 @@ bool EventAnalyzer::init() {
   INFO("Event analysis started.");
 
   getStatistics().createHistogramWithAxes(
-      new TH1D("z_res", "Resolution along Z", 100, -15., 15.),
+      new TH1D("z_res", "Resolution along Z", 301, -15.05, 15.05),
       "Z_{REC}-Z_{MC} [cm]");
 
   getStatistics().createHistogramWithAxes(
-      new TH1D("Edep_res", "Resolution of deposited energy", 100, -200., 200.),
+      new TH1D("Edep_res", "Resolution of deposited energy", 201, -201., 201.),
       "E_{REC}-E_{MC} [keV]");
 
   // Input events type

--- a/MCGeantAnalysis/EventAnalyzer.cpp
+++ b/MCGeantAnalysis/EventAnalyzer.cpp
@@ -28,12 +28,13 @@ EventAnalyzer::~EventAnalyzer() {}
 bool EventAnalyzer::init() {
   INFO("Event analysis started.");
 
-  getStatistics().createHistogram(new TH1F(
-      "z_res", "Resolution along Z;Z_{REC}-Z_{MC} [cm]", 100, -15., 15.));
+  getStatistics().createHistogramWithAxes(
+      new TH1D("z_res", "Resolution along Z", 100, -15., 15.),
+      "Z_{REC}-Z_{MC} [cm]");
 
-  getStatistics().createHistogram(new TH1F(
-      "Edep_res", "Resolution of deposited energy;E_{REC}-E_{MC} [keV]", 100,
-      -200., 200.));
+  getStatistics().createHistogramWithAxes(
+      new TH1D("Edep_res", "Resolution of deposited energy", 100, -200., 200.),
+      "E_{REC}-E_{MC} [keV]");
 
   // Input events type
   fOutputEvents = new JPetTimeWindow("JPetEvent");
@@ -90,10 +91,9 @@ void EventAnalyzer::fillResolutionHistograms(const JPetEvent &event,
     const JPetMCHit &mc_hit =
         tw->getMCHit<JPetMCHit>(reconstructed_hit.getMCindex());
 
-    getStatistics().getHisto1D("z_res")->Fill(reconstructed_hit.getPos().Z() -
-                                              mc_hit.getPos().Z());
-    getStatistics()
-        .getHisto1D("Edep_res")
-        ->Fill(reconstructed_hit.getEnergy() - mc_hit.getEnergy());
+    getStatistics().fillHistogram("z_res", reconstructed_hit.getPos().Z() -
+                                               mc_hit.getPos().Z());
+    getStatistics().fillHistogram("Edep_res", reconstructed_hit.getEnergy() -
+                                                  mc_hit.getEnergy());
   }
 }

--- a/MCGeantAnalysis/EventAnalyzer.cpp
+++ b/MCGeantAnalysis/EventAnalyzer.cpp
@@ -1,0 +1,98 @@
+/**
+ *  @copyright Copyright 2020 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  @file EventAnalyzer.cpp
+ */
+
+#include "EventAnalyzer.h"
+#include "../LargeBarrelAnalysis/EventCategorizerTools.h"
+#include <JPetMCHit/JPetMCHit.h>
+#include <JPetOptionsTools/JPetOptionsTools.h>
+#include <iostream>
+
+using namespace jpet_options_tools;
+using namespace std;
+
+EventAnalyzer::EventAnalyzer(const char *name) : JPetUserTask(name) {}
+
+EventAnalyzer::~EventAnalyzer() {}
+
+bool EventAnalyzer::init() {
+  INFO("Event analysis started.");
+
+  getStatistics().createHistogram(new TH1F(
+      "z_res", "Resolution along Z;Z_{REC}-Z_{MC} [cm]", 100, -15., 15.));
+
+  getStatistics().createHistogram(new TH1F(
+      "Edep_res", "Resolution of deposited energy;E_{REC}-E_{MC} [keV]", 100, -200., 200.));
+  
+  // Input events type
+  fOutputEvents = new JPetTimeWindow("JPetEvent");
+
+  return true;
+}
+
+bool EventAnalyzer::exec() {
+
+  // Identify whether the input events are MC or DATA.
+  // In case of MC, store the pointer to the TimeWindowMC object
+  // which contains "true MC" information about the generated events.
+  JPetTimeWindowMC *time_window_mc = nullptr;
+  if (time_window_mc = dynamic_cast<JPetTimeWindowMC *const>(fEvent)) {
+    fIsMC = true;
+    INFO("The input file is MC.");
+  } else {
+    INFO("The input file is DATA.");
+  }
+
+  if (auto timeWindow = dynamic_cast<const JPetTimeWindow *const>(fEvent)) {
+
+    for (uint i = 0; i < timeWindow->getNumberOfEvents(); i++) {
+      const auto &event =
+          dynamic_cast<const JPetEvent &>(timeWindow->operator[](i));
+
+      // if the input is MC, we fill resolution histograms
+      // to check if MC smearing works fine
+      if (fIsMC) {
+        fillResolutionHistograms(event, time_window_mc);
+      }
+    }
+
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+bool EventAnalyzer::terminate() {
+  INFO("Event analysis completed.");
+  return true;
+}
+
+void EventAnalyzer::fillResolutionHistograms(const JPetEvent &event, const JPetTimeWindowMC* tw) {
+
+  int hits_number = event.getHits().size();
+  for (int k = 0; k < hits_number; ++k) {
+    const JPetHit& reconstructed_hit = event.getHits().at(k);
+    // for each reconstructed hit, we access the corresponding
+    // "true MC" hit
+    const JPetMCHit& mc_hit = tw->getMCHit<JPetMCHit>(reconstructed_hit.getMCindex());    
+
+    getStatistics().getHisto1D("z_res")->Fill(reconstructed_hit.getPos().Z() -
+                                              mc_hit.getPos().Z());
+    getStatistics().getHisto1D("Edep_res")->Fill(reconstructed_hit.getEnergy() -
+                                                 mc_hit.getEnergy());
+    
+  }
+  
+}

--- a/MCGeantAnalysis/EventAnalyzer.cpp
+++ b/MCGeantAnalysis/EventAnalyzer.cpp
@@ -33,8 +33,9 @@ bool EventAnalyzer::init() {
       "z_res", "Resolution along Z;Z_{REC}-Z_{MC} [cm]", 100, -15., 15.));
 
   getStatistics().createHistogram(new TH1F(
-      "Edep_res", "Resolution of deposited energy;E_{REC}-E_{MC} [keV]", 100, -200., 200.));
-  
+      "Edep_res", "Resolution of deposited energy;E_{REC}-E_{MC} [keV]", 100,
+      -200., 200.));
+
   // Input events type
   fOutputEvents = new JPetTimeWindow("JPetEvent");
 
@@ -79,20 +80,21 @@ bool EventAnalyzer::terminate() {
   return true;
 }
 
-void EventAnalyzer::fillResolutionHistograms(const JPetEvent &event, const JPetTimeWindowMC* tw) {
+void EventAnalyzer::fillResolutionHistograms(const JPetEvent &event,
+                                             const JPetTimeWindowMC *tw) {
 
   int hits_number = event.getHits().size();
   for (int k = 0; k < hits_number; ++k) {
-    const JPetHit& reconstructed_hit = event.getHits().at(k);
+    const JPetHit &reconstructed_hit = event.getHits().at(k);
     // for each reconstructed hit, we access the corresponding
     // "true MC" hit
-    const JPetMCHit& mc_hit = tw->getMCHit<JPetMCHit>(reconstructed_hit.getMCindex());    
+    const JPetMCHit &mc_hit =
+        tw->getMCHit<JPetMCHit>(reconstructed_hit.getMCindex());
 
     getStatistics().getHisto1D("z_res")->Fill(reconstructed_hit.getPos().Z() -
                                               mc_hit.getPos().Z());
-    getStatistics().getHisto1D("Edep_res")->Fill(reconstructed_hit.getEnergy() -
-                                                 mc_hit.getEnergy());
-    
+    getStatistics()
+        .getHisto1D("Edep_res")
+        ->Fill(reconstructed_hit.getEnergy() - mc_hit.getEnergy());
   }
-  
 }

--- a/MCGeantAnalysis/EventAnalyzer.cpp
+++ b/MCGeantAnalysis/EventAnalyzer.cpp
@@ -13,11 +13,10 @@
  *  @file EventAnalyzer.cpp
  */
 
-#include "EventAnalyzer.h"
-#include "../LargeBarrelAnalysis/EventCategorizerTools.h"
 #include <JPetMCHit/JPetMCHit.h>
 #include <JPetOptionsTools/JPetOptionsTools.h>
-#include <iostream>
+#include "EventAnalyzer.h"
+#include "../LargeBarrelAnalysis/EventCategorizerTools.h"
 
 using namespace jpet_options_tools;
 using namespace std;

--- a/MCGeantAnalysis/EventAnalyzer.h
+++ b/MCGeantAnalysis/EventAnalyzer.h
@@ -16,10 +16,10 @@
 #ifndef EVENTANALYZER_H
 #define EVENTANALYZER_H
 
-#include "../LargeBarrelAnalysis/EventCategorizerTools.h"
 #include <JPetEvent/JPetEvent.h>
 #include <JPetHit/JPetHit.h>
 #include <JPetUserTask/JPetUserTask.h>
+#include "../LargeBarrelAnalysis/EventCategorizerTools.h"
 
 #ifdef __CINT__
 #define override

--- a/MCGeantAnalysis/EventAnalyzer.h
+++ b/MCGeantAnalysis/EventAnalyzer.h
@@ -1,0 +1,40 @@
+/**
+ *  @copyright Copyright 2020 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  @file EventAnalyzer.h
+ */
+
+#ifndef EVENTANALYZER_H
+#define EVENTANALYZER_H
+
+#include "../LargeBarrelAnalysis/EventCategorizerTools.h"
+#include <JPetEvent/JPetEvent.h>
+#include <JPetHit/JPetHit.h>
+#include <JPetUserTask/JPetUserTask.h>
+
+#ifdef __CINT__
+#define override
+#endif
+
+class EventAnalyzer : public JPetUserTask {
+public:
+  EventAnalyzer(const char *name);
+  virtual ~EventAnalyzer();
+  virtual bool init() override;
+  virtual bool exec() override;
+  virtual bool terminate() override;
+
+protected:
+  void fillResolutionHistograms(const JPetEvent &event, const JPetTimeWindowMC* tw);
+  bool fIsMC = false;
+};
+#endif /* !EVENTANALYZER_H */

--- a/MCGeantAnalysis/EventAnalyzer.h
+++ b/MCGeantAnalysis/EventAnalyzer.h
@@ -34,7 +34,8 @@ public:
   virtual bool terminate() override;
 
 protected:
-  void fillResolutionHistograms(const JPetEvent &event, const JPetTimeWindowMC* tw);
+  void fillResolutionHistograms(const JPetEvent &event,
+                                const JPetTimeWindowMC *tw);
   bool fIsMC = false;
 };
 #endif /* !EVENTANALYZER_H */

--- a/MCGeantAnalysis/PARAMETERS.md
+++ b/MCGeantAnalysis/PARAMETERS.md
@@ -54,7 +54,7 @@ String specifying a valid C++ lambda function which returns probability density 
 Arguments: `double* x` - variable smeared energy deposition [keV]
 Parameters: `double* p` - an array of default parameters + user-defined parameters provided as described above (p[0]=ScinID, p[1]=Z, p[2]=E, p[3]=T, p[4]=user parameter 1, p[5]=user parameter 2, ...).
 
--"GeantParser_EnergySmearingFunctionLimits_std::vector<double>"
+- "GeantParser_EnergySmearingFunctionLimits_std::vector<double>"
 Vector of two values specifying the limits (in keV) around the MC-generated Edep value inside which the smearing should be allowed. Use limits large enough not to truncate your smearing probability distributions!
 
 ## Parameters controlling hit time smearing:

--- a/MCGeantAnalysis/PARAMETERS.md
+++ b/MCGeantAnalysis/PARAMETERS.md
@@ -29,4 +29,44 @@ applying. This value influence on number of reconstructed hits and events.
 default value : false
 For testing purposes user can ask for processing single event per time window
 
-Note that presently there are no parameters allowing to control the smearing of generated hit properties such as interaction time and Z position resolution. In order to tune them, please modify the corresponding functions in the `JPetSmearingFunctions` class directly in the `j-pet-framework` code. User parameters allowing to control the smearing will be added in the future versions.
+## Parameters controlling Z position smearing:
+
+- "GeantParser_ZPositionSmearingParameters_std::vector<double>"
+Parameters passed to the Z position smearing function specified using the next parameter.
+This vector can have any number of elements, which will be available inside the smearing function as p[4], p[5] etc. (p[0]-p[3] are reserved for default parameters: (ScinID, Z, E, T)).
+
+- "GeantParser_ZPositionSmearingFunction_std::string"
+String specifying a valid C++ lambda function which returns probability density function of the smeared Z position.
+Arguments: `double* x` - variable smeared Z position [cm]
+Parameters: `double* p` - an array of default parameters + user-defined parameters provided as described above (p[0]=ScinID, p[1]=Z, p[2]=E, p[3]=T, p[4]=user parameter 1, p[5]=user parameter 2, ...).
+
+- "GeantParser_ZPositionSmearingFunctionLimits_std::vector<double>"
+Vector of two values specifying the limits (in cm) around the MC-generated Z position value inside which the smearing should be allowed. Use limits large enough not to truncate your smearing probability distributions!
+
+## Parameters controlling energy deposition smearing:
+
+- "GeantParser_EnergySmearingParameters_std::vector<double>"
+Parameters passed to the energy deposition smearing function specified using the next parameter.
+This vector can have any number of elements, which will be available inside the smearing function as p[4], p[5] etc. (p[0]-p[3] are reserved for default parameters: (ScinID, Z, E, T)).
+
+- "GeantParser_EnergySmearingFunction_std::string"
+String specifying a valid C++ lambda function which returns probability density function of the smeared deposited energy value.
+Arguments: `double* x` - variable smeared energy deposition [keV]
+Parameters: `double* p` - an array of default parameters + user-defined parameters provided as described above (p[0]=ScinID, p[1]=Z, p[2]=E, p[3]=T, p[4]=user parameter 1, p[5]=user parameter 2, ...).
+
+-"GeantParser_EnergySmearingFunctionLimits_std::vector<double>"
+Vector of two values specifying the limits (in keV) around the MC-generated Edep value inside which the smearing should be allowed. Use limits large enough not to truncate your smearing probability distributions!
+
+## Parameters controlling hit time smearing:
+
+- "GeantParser_TimeSmearingParameters_std::vector<double>"
+Parameters passed to the hit time smearing function specified using the next parameter.
+This vector can have any number of elements, which will be available inside the smearing function as p[4], p[5] etc. (p[0]-p[3] are reserved for default parameters: (ScinID, Z, E, T)).
+
+- "GeantParser_TimeSmearingFunction_std::string"
+String specifying a valid C++ lambda function which returns probability density function of the smeared hit time.
+Arguments: `double* x` - variable smeared hit time [ps]
+Parameters: `double* p` - an array of default parameters + user-defined parameters provided as described above (p[0]=ScinID, p[1]=Z, p[2]=E, p[3]=T, p[4]=user parameter 1, p[5]=user parameter 2, ...).
+
+- "GeantParser_TimeSmearingFunctionLimits_std::vector<double>"
+Vector of two values specifying the limits (in ps) around the MC-generated hit time inside which the smearing should be allowed. Use limits large enough not to truncate your smearing probability distributions!

--- a/MCGeantAnalysis/README.md
+++ b/MCGeantAnalysis/README.md
@@ -24,7 +24,7 @@ Finally, inspect the produced files, e.g. the resolution histograms in the `ana.
 ## Creating analysis modules to work on both MC and data
 The `EventAnalyzer` module contained in this example shows how the users can create modules which can transparently work on both MC and data files, executing some additional actions in case of processing MC. For example, `EventAnalyzer` compares the exact simulated values of hit Z position and deposited energy with their smeared counterparts, filling resolution histograms which are useful for checking whether the user-provided smearing functions work as desired.
 
-Please not also that in this example, `EventAnalyzer` is applied to the results of the standard `EventFinder` module from the `LargeBarrelAnalysis` example, which is completely agnostic of whether it is working on MC or data files.
+Please also note that in this example, `EventAnalyzer` is applied to the results of the standard `EventFinder` module from the `LargeBarrelAnalysis` example, which is completely agnostic of whether it is working on MC or data files.
 
 ## Controlling the MC smearing
 When the `mcGeant.root` MC files are processed, exact simulated values of:

--- a/MCGeantAnalysis/README.md
+++ b/MCGeantAnalysis/README.md
@@ -1,17 +1,52 @@
 # MCGeantAnalysis
 
 ## Aim
-Module is used to load a simulation files created with [J-PET-geant4](https://github.com/JPETTomography/J-PET-geant4). 
+This example demonstrates how to:
+- load a simulation files created with [J-PET-geant4](https://github.com/JPETTomography/J-PET-geant4)
+- apply and control smearing of MC-generated values of hit Z position, hit time and deposited energy using user-provided parameters
+- distinguish data and MC in an analysis module and access generated MC information when processing MC files
 
 ## Input and Output
 - Input file must have the `*.mcGeant.root`  
-- Also required is a `.json` which corresponds to simulated/analyzed run.
+- Also required is a `.json` file with detector setup which corresponds to simulated/analyzed run.
 Those files are the same as used while processing the data and can be taken from CalibrationFiles/X_RUN/detectorSetupRun.json
-- Output file created   `*.hits.root`  
+- Output files created   `*.hits.root`, `*.unk.evt.root`, `*.ana.evt.root`
 - No output to stdout,`JPet_(date).log` file appears with the log of the processing and ROOT files.
 
 ## How to use?
+Edit `userParams.json` to adjust the MC smearing functions and their parameters to match the simulated run conditions.
+
+Then start processing with:
 `./run.sh *.mcGeant.root`
 
-## Implemented features
-Detector geometry is created based on `detectorSetup.json` file provided by the user
+Finally, inspect the produced files, e.g. the resolution histograms in the `ana.evt.root` file.
+
+## Creating analysis modules to work on both MC and data
+The `EventAnalyzer` module contained in this example shows how the users can create modules which can transparently work on both MC and data files, executing some additional actions in case of processing MC. For example, `EventAnalyzer` compares the exact simulated values of hit Z position and deposited energy with their smeared counterparts, filling resolution histograms which are useful for checking whether the user-provided smearing functions work as desired.
+
+Please not also that in this example, `EventAnalyzer` is applied to the results of the standard `EventFinder` module from the `LargeBarrelAnalysis` example, which is completely agnostic of whether it is working on MC or data files.
+
+## Controlling the MC smearing
+When the `mcGeant.root` MC files are processed, exact simulated values of:
+
+- hit Z position
+
+- hit time
+
+- hit deposited energy
+
+are smeared to reflect the finite experimental resolutions.
+
+Users can control this smearing by specifying the probability density distributions of the smeared quantities as user parameters in the `userParams.json` file. Please refer to the [PARAMETERS](PARAMETERS.md) file for details.
+
+Each smearing PDF can depend on the following hit properties which are passed automatically as parameters:
+
+- scintillator ID (`p[0]`)
+
+- hit Z position (`p[1]`)
+
+- hit deposited energy (`p[2]`)
+
+- hit time(`p[3]`)
+
+as well as any number of arbitrary parameters which are passed as `p[4]`, `p[5]` and so on.

--- a/MCGeantAnalysis/main.cpp
+++ b/MCGeantAnalysis/main.cpp
@@ -15,7 +15,7 @@
 
 #include <JPetManager/JPetManager.h>
 #include "../LargeBarrelAnalysis/EventFinder.h"
-#include "../LargeBarrelAnalysis/EventCategorizer.h"
+#include "EventAnalyzer.h"
 using namespace std;
 
 int main(int argc, const char* argv[])
@@ -24,10 +24,10 @@ int main(int argc, const char* argv[])
     JPetManager& manager = JPetManager::getManager();
     
     manager.registerTask<EventFinder>("EventFinder");
-    manager.registerTask<EventCategorizer>("EventCategorizer");
+    manager.registerTask<EventAnalyzer>("EventAnalyzer");
     
-    manager.useTask("EventFinder", "mc.hits", "unk.evt");
-    manager.useTask("EventCategorizer", "unk.evt", "cat.evt");
+    manager.useTask("EventFinder", "hits", "unk.evt");
+    manager.useTask("EventAnalyzer", "unk.evt", "ana.evt");
     
     manager.run(argc, argv);
   } catch (const std::exception& except) {

--- a/MCGeantAnalysis/run.sh
+++ b/MCGeantAnalysis/run.sh
@@ -5,4 +5,4 @@ if [ -z ${3+x} ]; then
     exit 
 fi
 
-./MCGeantAnalysis.x -t mcGeant -f $1 -u userParams.json -l $2 -i $3 -u userParams.json
+./MCGeantAnalysis.x -t mcGeant -f $1 -u userParams.json -l $2 -i $3

--- a/MCGeantAnalysis/run.sh
+++ b/MCGeantAnalysis/run.sh
@@ -5,4 +5,4 @@ if [ -z ${3+x} ]; then
     exit 
 fi
 
-./MCGeantAnalysis.x -t mcGeant -f $1 -u userParams.json -l $2 -i $3
+./MCGeantAnalysis.x -t mcGeant -f $1 -u userParams.json -l $2 -i $3 -u userParams.json


### PR DESCRIPTION
Extensions of the example include:
- example of controlling MC smearing with user parameters
- creating an analysis module that works on both MC and data
- basic accessing of generated MC information
- documentation updates related to all of the above.