### PR TITLE
Test with "develop" branch rather than "cmake"

### DIFF
--- a/jenkins/root_6_matrix/docker-entrypoint.sh
+++ b/jenkins/root_6_matrix/docker-entrypoint.sh
@@ -12,7 +12,7 @@ executeCommand "export CMAKE_INCLUDE_PATH=$CMAKE_INCLUDE_PATH:/framework-depende
 executeCommand "source /root-system/bin/thisroot.sh"
 
 executeCommand "rm -rf j-pet-framework || true"
-executeCommand "git clone --single-branch --branch cmake https://github.com/grey277/j-pet-framework.git"
+executeCommand "git clone --single-branch --branch develop https://github.com/grey277/j-pet-framework.git"
 executeCommand "mkdir -p j-pet-framework/build"
 executeCommand "cd j-pet-framework/build"
 executeCommand "cmake .."


### PR DESCRIPTION
We had hard-coded testing of examples with the "cmake" branch of the core framework library. As this branch is far behind "develop", tests of examples now fail.

I am crating this PR to check whether the tests on Jenkins will pass now that it used the "develop" branch. If tests pass, this PR should be merged.