### PR TITLE
Add getRange function

### DIFF
--- a/LargeBarrelAnalysis/ToTEnergyConverter.cpp
+++ b/LargeBarrelAnalysis/ToTEnergyConverter.cpp
@@ -28,7 +28,7 @@ ToTEnergyConverter::ToTEnergyConverter(const ToTEParams& params, const ToTERange
 
 double ToTEnergyConverter::operator()(double x) const { return fFunction(x); }
 
-std::pair<double, double> ToTEnergyConverter::getEnergyRange() const { return {fFunction.getRange().fMin, fFunction.getRange().fMax };  }
+std::pair<double, double> ToTEnergyConverter::getRange() const { return {fFunction.getRange().fMin, fFunction.getRange().fMax };  }
 
 ToTEnergyConverter generateToTEnergyConverter(const FuncParamsAndLimits& formula)
 {
@@ -40,5 +40,4 @@ ToTEnergyConverter generateToTEnergyConverter(const FuncParamsAndLimits& formula
   ToTEnergyConverter conv(params, Range(100000, funcLimits.first, funcLimits.second));
   return conv;
 }
-
 }

--- a/LargeBarrelAnalysis/ToTEnergyConverter.cpp
+++ b/LargeBarrelAnalysis/ToTEnergyConverter.cpp
@@ -28,6 +28,8 @@ ToTEnergyConverter::ToTEnergyConverter(const ToTEParams& params, const ToTERange
 
 double ToTEnergyConverter::operator()(double x) const { return fFunction(x); }
 
+std::pair<double, double> ToTEnergyConverter::getEnergyRange() const { return {fFunction.getRange().fMin, fFunction.getRange().fMax };  }
+
 ToTEnergyConverter generateToTEnergyConverter(const FuncParamsAndLimits& formula)
 {
   auto func = formula.first;
@@ -38,4 +40,5 @@ ToTEnergyConverter generateToTEnergyConverter(const FuncParamsAndLimits& formula
   ToTEnergyConverter conv(params, Range(100000, funcLimits.first, funcLimits.second));
   return conv;
 }
+
 }

--- a/LargeBarrelAnalysis/ToTEnergyConverter.h
+++ b/LargeBarrelAnalysis/ToTEnergyConverter.h
@@ -30,6 +30,8 @@ class ToTEnergyConverter
 public:
   ToTEnergyConverter(const ToTEParams& params, ToTERange);
   double operator()(double val) const;
+  /// Function returns the range of energy for which the converter is valid
+  std::pair<double, double> getEnergyRange() const; 
 
 private:
   CachedFunction fFunction;

--- a/LargeBarrelAnalysis/ToTEnergyConverter.h
+++ b/LargeBarrelAnalysis/ToTEnergyConverter.h
@@ -30,8 +30,8 @@ class ToTEnergyConverter
 public:
   ToTEnergyConverter(const ToTEParams& params, ToTERange);
   double operator()(double val) const;
-  /// Function returns the range of energy for which the converter is valid
-  std::pair<double, double> getEnergyRange() const; 
+  /// Function returns the range of arguments for which the converter is valid
+  std::pair<double, double> getRange() const; 
 
 private:
   CachedFunction fFunction;


### PR DESCRIPTION
The function returns the range of arguments for which the converter is valid.
This PR must be accepted first: https://github.com/JPETTomography/j-pet-framework/pull/251