### PR TITLE
Fixing names of histograms in ECT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ find_package(Threads REQUIRED)
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.50 REQUIRED 
+find_package(Boost 1.50 REQUIRED
              COMPONENTS filesystem
                         program_options
                         regex
@@ -150,7 +150,7 @@ endif(JPetFramework_FOUND)
 ## The script shouldn't do anything if the data is present and correct.
 option(DOWNLOAD_DATA "Download data" ON)
 if(DOWNLOAD_DATA)
-  set(DOWNLOAD_BASE_PATH ${PROJECT_SOURCE_DIR})  
+  set(DOWNLOAD_BASE_PATH ${PROJECT_SOURCE_DIR})
 
   file(DOWNLOAD "http://sphinx.if.uj.edu.pl/framework/examples_reformed.sha" ${DOWNLOAD_BASE_PATH}/examples_reformed.sha)
   file(READ ${DOWNLOAD_BASE_PATH}/examples_reformed.sha SHA_HASHES)

--- a/LargeBarrelAnalysis/EventCategorizer.cpp
+++ b/LargeBarrelAnalysis/EventCategorizer.cpp
@@ -136,59 +136,89 @@ void EventCategorizer::initialiseHistograms(){
 
   // General histograms
   getStatistics().createHistogramWithAxes(
-      new TH2D("All_XYpos", "Hit position XY", 240, -60.25, 59.75, 240, -60.25, 59.75),
-                                            "Hit X position [cm]", "Hit Y position [cm]");
+    new TH2D("All_XYpos", "Hit position XY", 240, -60.25, 59.75, 240, -60.25, 59.75),
+    "Hit X position [cm]", "Hit Y position [cm]"
+  );
 
   // Histograms for 2Gamama category
   getStatistics().createHistogramWithAxes(
-      new TH1D("2Gamma_Zpos", "B2B hits Z position", 200, -50.25, 49.75),
-                                            "Z axis position [cm]", "Number of Hits");
+    new TH1D("2Gamma_Zpos", "Z-axis position of 2 gamma hits", 201, -50.25, 50.25),
+    "Z axis position [cm]", "Number of Hits"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH1D("2Gamma_DLOR", "Delta LOR distance", 100, -0.25, 49.25),
-                                            "Delta LOR [cm]", "Counts");
+    new TH1D("2Gamma_DLOR", "Delta LOR distance", 100, -0.25, 49.25),
+    "Delta LOR [cm]", "Counts"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH1D("2Gamma_ThetaDiff", "2 Gamma Hits angles", 180, -0.5, 179.5),
-                                            "Hits theta diff [deg]", "Counts");
+    new TH1D("2Gamma_ThetaDiff", "Difference of angles of 2 gamma hits ", 181, -0.5, 180.5),
+    "Hits theta diff [deg]", "Counts"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH1D("2Gamma_TimeDiff", "B2B hits time difference", 100, -10100.0, 99900.0),
-                                            "Time Difference [ps]", "Number of Hit Pairs");
+    new TH1D("2Gamma_TimeDiff", "Time difference of 2 gamma hits", 200, -10100.0, 99900.0),
+    "Time Difference [ps]", "Number of Hit Pairs"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH1D("2Gamma_Dist", "B2B hits distance", 150, -0.5, 149.5),
-                                            "Distance [cm]", "Number of Hit Pairs");
+    new TH1D("2Gamma_Dist", "B2B hits distance", 150, -0.5, 149.5),
+    "Distance [cm]", "Number of Hit Pairs"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH1D("Annih_TOF", "Annihilation pairs Time of Flight", 200, -3015.0, 2985.0),
-                                            "Time of Flight [ps]", "Number of Annihilation Pairs");
+    new TH1D("Annih_TOF", "Annihilation pairs Time of Flight", 201, -3015.0, 3015.0),
+    "Time of Flight [ps]", "Number of Annihilation Pairs"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH2D("AnnihPoint_XY", "XY position of annihilation point", 240, -60.25, 59.75, 240, -60.25, 59.75),
-                                            "X position [cm]", "Y position [cm]");
+    new TH2D("AnnihPoint_XY", "XY position of annihilation point", 240, -60.25, 59.75, 240, -60.25, 59.75),
+    "X position [cm]", "Y position [cm]"
+  );
+
   getStatistics().createHistogramWithAxes(
-      new TH2D("AnnihPoint_XZ", "XZ position of annihilation point", 240, -60.25, 59.75, 240, -60.25, 59.75),
-                                            "X position [cm]", "Z position [cm]");
+    new TH2D("AnnihPoint_ZX", "ZX position of annihilation point", 240, -60.25, 59.75, 240, -60.25, 59.75),
+    "Z position [cm]", "X position [cm]"
+  );
+
   getStatistics().createHistogramWithAxes(
-    new TH2D("AnnihPoint_YZ", "YZ position of annihilation point", 240, -60.25, 59.75, 240, -60.25, 59.75),
-                                            "Y position [cm]", "Z position [cm]");
+    new TH2D("AnnihPoint_ZY", "ZY position of annihilation point", 240, -60.25, 59.75, 240, -60.25, 59.75),
+    "Z position [cm]", "Y position [cm]"
+  );
+
+  getStatistics().createHistogramWithAxes(
+    new TH1D("Annih_DLOR", "Delta LOR distance of annihilation photons", 100, -0.25, 49.25),
+    "Delta LOR [cm]", "Counts"
+  );
 
   // Histograms for 3Gamama category
   getStatistics().createHistogramWithAxes(
     new TH2D("3Gamma_Angles", "Relative angles - transformed", 250, -0.5, 249.5, 20, -0.5, 199.5),
-                                            "Relative angle 1-2", "Relative angle 2-3");
+    "Relative angle 1-2", "Relative angle 2-3"
+  );
 
   // Histograms for scattering category
   getStatistics().createHistogramWithAxes(
-    new TH1D("ScatterTOF_TimeDiff", "Difference of Scatter TOF and hits time difference", 
-                                            3.0*fScatterTOFTimeDiff, -0.5, 3.0*fScatterTOFTimeDiff-0.5),
-                                            "Scat_TOF & time diff [ps]", "Number of Hit Pairs");
+    new TH1D("ScatterTOF_TimeDiff", "Difference of Scatter TOF and hits time difference",
+    3.0*fScatterTOFTimeDiff, -0.5, 3.0*fScatterTOFTimeDiff-0.5),
+    "Scat_TOF & time diff [ps]", "Number of Hit Pairs"
+  );
+
   getStatistics().createHistogramWithAxes(
-     new TH2D("ScatterAngle_PrimaryTOT", "Angle of scattering vs. TOT of primary hits",
-                                            200, -0.5, 199.5, 200, -100.0, 39900.0),
-                                            "Scattering Angle", "TOT of primary hit [ps]");
+    new TH2D("ScatterAngle_PrimaryTOT", "Angle of scattering vs. TOT of primary hits",
+    200, -0.5, 199.5, 200, -100.0, 39900.0),
+    "Scattering Angle", "TOT of primary hit [ps]"
+  );
+
   getStatistics().createHistogramWithAxes(
-     new TH2D("ScatterAngle_ScatterTOT", "Angle of scattering vs. TOT of scattered hits",
-                                            200, -0.5, 199.5, 200, -100.0, 39900.0),
-                                            "Scattering Angle", "TOT of scattered hit [ps]");
+    new TH2D("ScatterAngle_ScatterTOT", "Angle of scattering vs. TOT of scattered hits",
+    200, -0.5, 199.5, 200, -100.0, 39900.0),
+    "Scattering Angle", "TOT of scattered hit [ps]"
+  );
 
   // Histograms for deexcitation
   getStatistics().createHistogramWithAxes(
     new TH1D("Deex_TOT_cut", "TOT of all hits with deex cut (30,50) ns", 200, 24950.0, 54950.0),
-                                            "TOT [ps]", "Number of Hits");
+    "TOT [ps]", "Number of Hits"
+  );
 }

--- a/LargeBarrelAnalysis/EventCategorizer.cpp
+++ b/LargeBarrelAnalysis/EventCategorizer.cpp
@@ -140,7 +140,7 @@ void EventCategorizer::initialiseHistograms(){
     "Hit X position [cm]", "Hit Y position [cm]"
   );
 
-  // Histograms for 2Gamama category
+  // Histograms for 2Gamma category
   getStatistics().createHistogramWithAxes(
     new TH1D("2Gamma_Zpos", "Z-axis position of 2 gamma hits", 201, -50.25, 50.25),
     "Z axis position [cm]", "Number of Hits"
@@ -152,7 +152,7 @@ void EventCategorizer::initialiseHistograms(){
   );
 
   getStatistics().createHistogramWithAxes(
-    new TH1D("2Gamma_ThetaDiff", "Difference of angles of 2 gamma hits ", 181, -0.5, 180.5),
+    new TH1D("2Gamma_ThetaDiff", "Angle difference of 2 gamma hits ", 181, -0.5, 180.5),
     "Hits theta diff [deg]", "Counts"
   );
 

--- a/LargeBarrelAnalysis/EventCategorizerTools.cpp
+++ b/LargeBarrelAnalysis/EventCategorizerTools.cpp
@@ -47,18 +47,21 @@ bool EventCategorizerTools::checkFor2Gamma(
       double theta2 = max(firstHit.getBarrelSlot().getTheta(), secondHit.getBarrelSlot().getTheta());
       double thetaDiff = min(theta2 - theta1, 360.0 - theta2 + theta1);
       if (saveHistos) {
+        stats.fillHistogram("2Gamma_Zpos", firstHit.getPosZ());
+        stats.fillHistogram("2Gamma_Zpos", secondHit.getPosZ());
         stats.fillHistogram("2Gamma_TimeDiff", timeDiff / 1000.0);
         stats.fillHistogram("2Gamma_DLOR", deltaLor);
         stats.fillHistogram("2Gamma_ThetaDiff", thetaDiff);
+        stats.fillHistogram("2Gamma_Dist", calculateDistance(firstHit, secondHit));
       }
       if (fabs(thetaDiff - 180.0) < b2bSlotThetaDiff && timeDiff < b2bTimeDiff) {
         if (saveHistos) {
           TVector3 annhilationPoint = calculateAnnihilationPoint(firstHit, secondHit);
-          stats.fillHistogram("2Annih_TimeDiff", timeDiff / 1000.0);
-          stats.fillHistogram("2Annih_DLOR", deltaLor);
-          stats.fillHistogram("2Annih_ThetaDiff", thetaDiff);
-          stats.fillHistogram("2Annih_XY", annhilationPoint.X(), annhilationPoint.Y());
-          stats.fillHistogram("2Annih_Z", annhilationPoint.Z());
+          stats.fillHistogram("Annih_TOF", calculateTOFByConvention(firstHit, secondHit));
+          stats.fillHistogram("AnnihPoint_XY", annhilationPoint.X(), annhilationPoint.Y());
+          stats.fillHistogram("AnnihPoint_ZX", annhilationPoint.Z(), annhilationPoint.X());
+          stats.fillHistogram("AnnihPoint_ZY", annhilationPoint.Z(), annhilationPoint.Y());
+          stats.fillHistogram("Annih_DLOR", deltaLor);
         }
         return true;
       }
@@ -170,10 +173,10 @@ bool EventCategorizerTools::checkForScatter(
 double EventCategorizerTools::calculateTOT(const JPetHit& hit, TOTCalculationType type)
 {
   double tot = 0.0;
-           
+
   std::map<int, double> thrToTOT_sideA = hit.getSignalA().getRecoSignal().getRawSignal().getTOTsVsThresholdValue();
   std::map<int, double> thrToTOT_sideB = hit.getSignalB().getRecoSignal().getRawSignal().getTOTsVsThresholdValue();
-  
+
   tot += calculateTOTside(thrToTOT_sideA, type);
   tot += calculateTOTside(thrToTOT_sideB, type);
   return tot;


### PR DESCRIPTION
As reported on [redmine](http://sphinx.if.uj.edu.pl/redmine/issues/1378), this PR fixes names of histograms used in EventCategorizerTools but declared under different names in EventCategorizer. 

Also small fixes in binning and indentation. 