### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     - name: build framework examples 
       run: |
         source root/bin/thisroot.sh
-        j-pet-framework/build/bin/thisframework.sh
+        source j-pet-framework/build/bin/thisframework.sh
         mkdir build
         cd build
         cmake ..

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,12 +32,12 @@ jobs:
         cd j-pet-framework/build
         cmake ..
         cmake --build .
-        sudo make install
         cd ../..
 
     - name: build framework examples 
       run: |
         source root/bin/thisroot.sh
+        j-pet-framework/build/bin/thisframework.sh
         mkdir build
         cd build
         cmake ..


### PR DESCRIPTION
A minimal modification of the testing setup to make the tests work on Ubuntu18.04 after deprecating RPATH in favor of RUNPATH:
https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1737608
https://stackoverflow.com/questions/59248421/c-secondary-dependency-resolution-with-runpath

This will make the tests link properly for now with no harm for user code.

I a longer run, we will need a more systemic solution though, see:
http://sphinx.if.uj.edu.pl/redmine/issues/1382