### PR TITLE
Update activity param. description

### DIFF
--- a/MCGeantAnalysis/PARAMETERS.md
+++ b/MCGeantAnalysis/PARAMETERS.md
@@ -12,7 +12,7 @@ See comment above
 default value [MBq]: 4.7
 Activity for the analyzed run. The provided acvitivy will be used to distribute the simulated events in the time windows in appropriate time intervals.
 Please note that application of the provided source activity assumes that complete output of MC simulations with [J-PET-geant4](https://github.com/JPETTomography/J-PET-geant4/) was saved to the mcGeant.root files.
-In case the MC-su,ilated events were filtered e.g. by requirements of a given number of recorded hits, the applied source activity will not be physically meaningful.
+In case the MC-simulated events were filtered e.g. by requirements of a given number of recorded hits, the applied source activity will not be physically meaningful.
 
 - "GeantParser_MakeHistograms_bool"
 default value : true

--- a/MCGeantAnalysis/PARAMETERS.md
+++ b/MCGeantAnalysis/PARAMETERS.md
@@ -10,7 +10,9 @@ See comment above
 
 - "GeantParser_SourceActivity_double"
 default value [MBq]: 4.7
-Activity for the analyzed run - see proper report at PetWiki
+Activity for the analyzed run. The provided acvitivy will be used to distribute the simulated events in the time windows in appropriate time intervals.
+Please note that application of the provided source activity assumes that complete output of MC simulations with [J-PET-geant4](https://github.com/JPETTomography/J-PET-geant4/) was saved to the mcGeant.root files.
+In case the MC-su,ilated events were filtered e.g. by requirements of a given number of recorded hits, the applied source activity will not be physically meaningful.
 
 - "GeantParser_MakeHistograms_bool"
 default value : true


### PR DESCRIPTION
Following the discussion from one of the developers' meetings, I have added a comment about the SourceActivity parameter of GeantParser losing meaning when the input simulations had been pre-filtered.