### PR TITLE
Add explicit call to JPetEventType

### DIFF
--- a/UserDataClassExample/JPetLORevent.cpp
+++ b/UserDataClassExample/JPetLORevent.cpp
@@ -29,7 +29,7 @@ JPetLORevent::JPetLORevent(const std::vector<JPetHit> &hits,
 }
 
 void JPetLORevent::Clear(Option_t *) {
-  fType = kUnknown;
+  fType = JPetEventType::kUnknown;
   fHits.clear();
 }
 


### PR DESCRIPTION
It is needed after changing the enum definition to the scoped one.
Should be added after https://github.com/JPETTomography/j-pet-framework/pull/276