### PR TITLE
Remove #ifndef __CINT__ from all files

### DIFF
--- a/CosmicAnalysis/EventCategorizerCosmic.h
+++ b/CosmicAnalysis/EventCategorizerCosmic.h
@@ -25,10 +25,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#	define override
-#endif
-
 class EventCategorizerCosmic : public JPetUserTask
 {
 public:

--- a/ImageReconstruction/FilterEvents.h
+++ b/ImageReconstruction/FilterEvents.h
@@ -16,12 +16,6 @@
 #ifndef FILTEREVENTS_H
 #define FILTEREVENTS_H
 
-#ifdef __CINT__
-//when cint is used instead of compiler, override word is not recognized
-//nevertheless it's needed for checking if the structure of project is correct
-#define override
-#endif
-
 #include "JPetUserTask/JPetUserTask.h"
 #include <memory>
 

--- a/ImageReconstruction/ImageReco.h
+++ b/ImageReconstruction/ImageReco.h
@@ -16,12 +16,6 @@
 #ifndef IMAGERECO_H
 #define IMAGERECO_H
 
-#ifdef __CINT__
-//when cint is used instead of compiler, override word is not recognized
-//nevertheless it's needed for checking if the structure of project is correct
-#define override
-#endif
-
 #include "JPetUserTask/JPetUserTask.h"
 #include <memory>
 

--- a/ImageReconstruction/MLEMRunner.h
+++ b/ImageReconstruction/MLEMRunner.h
@@ -16,12 +16,6 @@
 #ifndef MLEMRUNNER_H
 #define MLEMRUNNER_H
 
-#ifdef __CINT__
-// when cint is used instead of compiler, override word is not recognized
-// nevertheless it's needed for checking if the structure of project is correct
-#define override
-#endif
-
 #include "JPetEvent/JPetEvent.h"
 #include "JPetLoggerInclude.h"
 #include "JPetUserTask/JPetUserTask.h"

--- a/ImageReconstruction/Reconstruction/JPetRecoImageTools/JPetSinogramType.h
+++ b/ImageReconstruction/Reconstruction/JPetRecoImageTools/JPetSinogramType.h
@@ -16,17 +16,15 @@
 #ifndef _JPET_SinogramType_H_
 #define _JPET_SinogramType_H_
 
-#ifndef __CINT__
+#include <boost/version.hpp>
 #if BOOST_VERSION >= 106400
-#  include <boost/serialization/array_wrapper.hpp>
+  #include <boost/serialization/array_wrapper.hpp>
 #endif
 #include <boost/numeric/ublas/matrix_sparse.hpp>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#endif
-
 
 #include "JPetWriter/JPetWriter.h"
 

--- a/ImageReconstruction/ReconstructionTask.h
+++ b/ImageReconstruction/ReconstructionTask.h
@@ -16,12 +16,6 @@
 #ifndef ReconstructionTask_H
 #define ReconstructionTask_H
 
-#ifdef __CINT__
-// when cint is used instead of compiler, override word is not recognized
-// nevertheless it's needed for checking if the structure of project is correct
-#define override
-#endif
-
 #include <string>
 #include <vector>
 

--- a/ImageReconstruction/SinogramCreator.h
+++ b/ImageReconstruction/SinogramCreator.h
@@ -16,12 +16,6 @@
 #ifndef SINOGRAMCREATOR_H
 #define SINOGRAMCREATOR_H
 
-#ifdef __CINT__
-// when cint is used instead of compiler, override word is not recognized
-// nevertheless it's needed for checking if the structure of project is correct
-#define override
-#endif
-
 #include "JPetGeomMapping/JPetGeomMapping.h"
 #include "JPetHit/JPetHit.h"
 #include "JPetUserTask/JPetUserTask.h"

--- a/ImageReconstruction/SinogramCreatorTools.h
+++ b/ImageReconstruction/SinogramCreatorTools.h
@@ -16,12 +16,6 @@
 #ifndef SINOGRAMCREATORTOOLS_H
 #define SINOGRAMCREATORTOOLS_H
 
-#ifdef __CINT__
-// when cint is used instead of compiler, override word is not recognized
-// nevertheless it's needed for checking if the structure of project is correct
-#define override
-#endif
-
 #include <cmath>
 #include <tuple>
 #include <utility>

--- a/Imaging/EventCategorizerImaging.h
+++ b/Imaging/EventCategorizerImaging.h
@@ -26,10 +26,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#	define override
-#endif
-
 class EventCategorizerImaging : public JPetUserTask
 {
 public:

--- a/InterThresholdCalibration/InterThresholdCalibration.h
+++ b/InterThresholdCalibration/InterThresholdCalibration.h
@@ -21,11 +21,6 @@
 #include <JPetGeomMapping/JPetGeomMapping.h>
 #include <JPetTimer/JPetTimer.h>
 class JPetWriter;
-#ifdef __CINT__
-//when cint is used instead of compiler, override word is not recognized
-//nevertheless it's needed for checking if the structure of project is correct
-#	define override
-#endif
 class InterThresholdCalibration: public JPetUserTask
 {
 public:

--- a/LargeBarrelAnalysis/EventCategorizer.h
+++ b/LargeBarrelAnalysis/EventCategorizer.h
@@ -25,10 +25,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#	define override
-#endif
-
 /**
  * @brief User Task categorizing Events
  *

--- a/LargeBarrelAnalysis/EventFinder.h
+++ b/LargeBarrelAnalysis/EventFinder.h
@@ -24,10 +24,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#define override
-#endif
-
 /**
  * @brief User Task creating JPetEvent from hits
  *

--- a/LargeBarrelAnalysis/HitFinder.h
+++ b/LargeBarrelAnalysis/HitFinder.h
@@ -25,10 +25,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#define override
-#endif
-
 /**
  * @brief User Task creating JPetHit from matched Singlas
  *

--- a/LargeBarrelAnalysis/SignalFinder.h
+++ b/LargeBarrelAnalysis/SignalFinder.h
@@ -23,10 +23,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#define override
-#endif
-
 /**
  * @brief User Task: method organizing Signal Channels to Raw Signals
  *

--- a/LargeBarrelAnalysis/SignalTransformer.h
+++ b/LargeBarrelAnalysis/SignalTransformer.h
@@ -19,10 +19,6 @@
 #include "JPetRecoSignal/JPetRecoSignal.h"
 #include "JPetUserTask/JPetUserTask.h"
 
-#ifdef __CINT__
-#define override
-#endif
-
 class JPetWriter;
 
 /**

--- a/LargeBarrelAnalysis/TimeWindowCreator.h
+++ b/LargeBarrelAnalysis/TimeWindowCreator.h
@@ -24,10 +24,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#define override
-#endif
-
 /**
  * @brief User Task: translate Unpacker EventIII data to JPetTimeWindow
  *

--- a/MCGeantAnalysis/EventAnalyzer.h
+++ b/MCGeantAnalysis/EventAnalyzer.h
@@ -21,10 +21,6 @@
 #include <JPetUserTask/JPetUserTask.h>
 #include "../LargeBarrelAnalysis/EventCategorizerTools.h"
 
-#ifdef __CINT__
-#define override
-#endif
-
 class EventAnalyzer : public JPetUserTask {
 public:
   EventAnalyzer(const char *name);

--- a/PhysicAnalysis/EventCategorizerPhysics.h
+++ b/PhysicAnalysis/EventCategorizerPhysics.h
@@ -26,10 +26,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#	define override
-#endif
-
 class EventCategorizerPhysics : public JPetUserTask{
 public:
 	EventCategorizerPhysics(const char * name);

--- a/TimeCalibration/TimeCalibration.h
+++ b/TimeCalibration/TimeCalibration.h
@@ -21,11 +21,6 @@
 #include <JPetRawSignal/JPetRawSignal.h>
 #include <JPetGeomMapping/JPetGeomMapping.h>
 class JPetWriter;
-#ifdef __CINT__
-//when cint is used instead of compiler, override word is not recognized
-//nevertheless it's needed for checking if the structure of project is correct
-#	define override
-#endif
 class TimeCalibration:public JPetUserTask{
 public:
 	TimeCalibration(const char * name);

--- a/TimeCalibration_iter/TimeCalibration.h
+++ b/TimeCalibration_iter/TimeCalibration.h
@@ -25,11 +25,6 @@
 #include <memory>
 #include <vector>
 #include <string>
-#ifdef __CINT__
-//when cint is used instead of compiler, override word is not recognized
-//nevertheless it's needed for checking if the structure of project is correct
-#	define override
-#endif
 class TimeCalibration: public JPetUserTask
 {
 public:

--- a/UserDataClassExample/LORFinder.h
+++ b/UserDataClassExample/LORFinder.h
@@ -24,10 +24,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#define override
-#endif
-
 class LORFinder : public JPetUserTask {
 
 public:

--- a/VelocityCalibration/DeltaTFinder.h
+++ b/VelocityCalibration/DeltaTFinder.h
@@ -32,10 +32,6 @@
 
 class JPetWriter;
 
-#ifdef __CINT__
-#	define override
-#endif
-
 class DeltaTFinder : public JPetUserTask{
 public:
 	DeltaTFinder(const char * name);


### PR DESCRIPTION
This PR removes all occurrences of ``#ifndef __CINT__``. 
Root 6 already supports c++11, but it still defines ``__CINT__`` and this ``ifndef`` makes ``root`` to sometimes fail.

Signed-off-by: Kamil Rakoczy <kamilrakoczy1@gmail.com>