### PR TITLE
Fix FFTW target_link_libraries in ImageReconstruction

### DIFF
--- a/ImageReconstruction/Reconstruction/CMakeLists.txt
+++ b/ImageReconstruction/Reconstruction/CMakeLists.txt
@@ -69,4 +69,4 @@ target_include_directories(${projectName} PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${projectName}>
                            $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>)
-target_link_libraries(${projectName} PRIVATE JPetFramework::JPetFramework ${FFTW_LIBRARIES})
+target_link_libraries(${projectName} PRIVATE JPetFramework::JPetFramework FFTW::Double)


### PR DESCRIPTION
This PR fixes target_link_libraries for ``FFTW`` library in ``ImageReconstruction``.

Signed-off-by: Kamil Rakoczy <kamilrakoczy1@gmail.com>