### PR TITLE
Correcting trapeze method - proper adding triangle

### DIFF
--- a/LargeBarrelAnalysis/HitFinderTools.cpp
+++ b/LargeBarrelAnalysis/HitFinderTools.cpp
@@ -315,7 +315,7 @@ double HitFinderTools::calculateTOTside(const std::map<int, double> & thrToTOT_s
             break;
         case TOTCalculationType::kThresholdTrapeze:
             weight = (it->first - std::prev(it, 1)->first)/firstThr;
-            tot += weight*fabs(it->second - std::prev(it, 1)->second)/2; //fabs, because we do not know which TOT is lower
+            tot += weight*(std::prev(it, 1)->second - it->second)/2; //fabs, because we do not know which TOT is lower
             break;
         }
         tot += weight*it->second;

--- a/LargeBarrelAnalysis/HitFinderTools.cpp
+++ b/LargeBarrelAnalysis/HitFinderTools.cpp
@@ -315,7 +315,7 @@ double HitFinderTools::calculateTOTside(const std::map<int, double> & thrToTOT_s
             break;
         case TOTCalculationType::kThresholdTrapeze:
             weight = (it->first - std::prev(it, 1)->first)/firstThr;
-            tot += weight*(it->second - std::prev(it, 1)->second)/2;
+            tot += weight*fabs(it->second - std::prev(it, 1)->second)/2; //fabs, because we do not know which TOT is lower
             break;
         }
         tot += weight*it->second;

--- a/LargeBarrelAnalysis/HitFinderTools.cpp
+++ b/LargeBarrelAnalysis/HitFinderTools.cpp
@@ -315,7 +315,7 @@ double HitFinderTools::calculateTOTside(const std::map<int, double> & thrToTOT_s
             break;
         case TOTCalculationType::kThresholdTrapeze:
             weight = (it->first - std::prev(it, 1)->first)/firstThr;
-            tot += weight*(std::prev(it, 1)->second - it->second)/2; //fabs, because we do not know which TOT is lower
+            tot += weight*fabs(std::prev(it, 1)->second - it->second)/2; //fabs, because we do not know which TOT is lower
             break;
         }
         tot += weight*it->second;


### PR DESCRIPTION
There was a mistake in calculation of the TOT by trapeze method - wrong sign of the addition of the triangle component.

Fixed by adding fabs function, as it will be more general, when we do not know which TOTs will be smaller.