### PR TITLE
New module for downscaling events with certain numbers of hits

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+UseTab: Never
+TabWidth: 2
+Standard: Cpp11
+IndentWidth: 2
+PointerBindsToType: true
+ColumnLimit: 150
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBraces: Allman

--- a/LargeBarrelAnalysis/CMakeLists.txt
+++ b/LargeBarrelAnalysis/CMakeLists.txt
@@ -34,7 +34,8 @@ set(AUXILIARY_FILES
 set(projectBinary ${projectName}.x)
 project(${projectName} CXX)
 
-set(HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizer.h
+set(HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/Downscaler.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizer.h
             ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizerTools.h
             ${CMAKE_CURRENT_SOURCE_DIR}/EventFinder.h
             ${CMAKE_CURRENT_SOURCE_DIR}/HitFinder.h
@@ -48,7 +49,8 @@ set(HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizer.h
             ${CMAKE_CURRENT_SOURCE_DIR}/ToTEnergyConverter.h
             ${CMAKE_CURRENT_SOURCE_DIR}/ToTEnergyConverterFactory.h)
 
-set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizer.cpp
+set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/Downscaler.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizer.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/EventCategorizerTools.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/EventFinder.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/HitFinder.cpp

--- a/LargeBarrelAnalysis/Downscaler.cpp
+++ b/LargeBarrelAnalysis/Downscaler.cpp
@@ -20,72 +20,80 @@
 using namespace jpet_options_tools;
 using namespace std;
 
-Downscaler::Downscaler(const char *name) : JPetUserTask(name) {
+Downscaler::Downscaler(const char* name) : JPetUserTask(name)
+{
   std::random_device rd;
   fRandomGenerator = std::mt19937(rd());
 }
 
 Downscaler::~Downscaler() {}
 
-bool Downscaler::init() {
+bool Downscaler::init()
+{
   INFO("Event downscaling started.");
 
   // Parameter for back to back categorization
-  if (isOptionSet(fParams.getOptions(), fDownscalingRatesKey)) {
-    fDownscalingRates =
-        getOptionAsVectorOfDoubles(fParams.getOptions(), fDownscalingRatesKey);
-  } else {
+  if (isOptionSet(fParams.getOptions(), fDownscalingRatesKey))
+  {
+    fDownscalingRates = getOptionAsVectorOfDoubles(fParams.getOptions(), fDownscalingRatesKey);
+  }
+  else
+  {
     WARNING("No downscaling rates provided by the user. All events will be "
             "passed on at a 100% rate.");
   }
 
-  getStatistics().createHistogramWithAxes(
-      new TH1D("filtered_event_multiplicity",
-               "Number of hits in filtered events", 20, 0.5, 20.5),
-      "Hits in Event", "Number of Hits");
+  getStatistics().createHistogramWithAxes(new TH1D("filtered_event_multiplicity", "Number of hits in filtered events", 20, 0.5, 20.5),
+                                          "Hits in Event", "Number of Hits");
 
   fOutputEvents = new JPetTimeWindow("JPetEvent");
 
   return true;
 }
 
-bool Downscaler::exec() {
-  if (auto timeWindow = dynamic_cast<const JPetTimeWindow *const>(fEvent)) {
+bool Downscaler::exec()
+{
+  if (auto timeWindow = dynamic_cast<const JPetTimeWindow* const>(fEvent))
+  {
     vector<JPetEvent> events;
-    for (uint i = 0; i < timeWindow->getNumberOfEvents(); i++) {
-      const auto &event =
-          dynamic_cast<const JPetEvent &>(timeWindow->operator[](i));
+    for (uint i = 0; i < timeWindow->getNumberOfEvents(); i++)
+    {
+      const auto& event = dynamic_cast<const JPetEvent&>(timeWindow->operator[](i));
 
       int multiplicity = event.getHits().size();
       double rate = 1.0;
-      if (multiplicity <= fDownscalingRates.size()) {
+      if (multiplicity <= fDownscalingRates.size())
+      {
         rate = fDownscalingRates[multiplicity - 1] / 100.;
-        if (getNormalizedRandom() < rate) {
+        if (getNormalizedRandom() < rate)
+        {
           saveEvent(event);
         }
-      } else { // rate not specified for this multiplicity
+      }
+      else
+      { // rate not specified for this multiplicity
         saveEvent(event);
       }
     }
-
-  } else {
+  }
+  else
+  {
     return false;
   }
   return true;
 }
 
-bool Downscaler::terminate() {
+bool Downscaler::terminate()
+{
   INFO("Event downscaling completed.");
   return true;
 }
 
-double Downscaler::getNormalizedRandom() {
-  return fRandomDistribution(fRandomGenerator);
-}
+double Downscaler::getNormalizedRandom() { return fRandomDistribution(fRandomGenerator); }
 
-void Downscaler::saveEvent(const JPetEvent &event) {
+void Downscaler::saveEvent(const JPetEvent& event)
+{
 
-  getStatistics().fillHistogram("filtered_event_multiplicity",
-                                event.getHits().size());
+  getStatistics().fillHistogram("filtered_event_multiplicity", event.getHits().size());
   fOutputEvents->add<JPetEvent>(event);
 }

--- a/LargeBarrelAnalysis/Downscaler.cpp
+++ b/LargeBarrelAnalysis/Downscaler.cpp
@@ -16,6 +16,7 @@
 #include "Downscaler.h"
 #include <JPetOptionsTools/JPetOptionsTools.h>
 #include <iostream>
+#include <algorithm>
 
 using namespace jpet_options_tools;
 using namespace std;
@@ -36,6 +37,7 @@ bool Downscaler::init()
   if (isOptionSet(fParams.getOptions(), fDownscalingRatesKey))
   {
     fDownscalingRates = getOptionAsVectorOfDoubles(fParams.getOptions(), fDownscalingRatesKey);
+    std::transform(fDownscalingRates.begin(), fDownscalingRates.end(), fDownscalingRates.begin(), [](double el) -> double { return el / 100.; });
   }
   else
   {
@@ -64,7 +66,7 @@ bool Downscaler::exec()
       double rate = 1.0;
       if (multiplicity <= fDownscalingRates.size())
       {
-        rate = fDownscalingRates[multiplicity - 1] / 100.;
+        rate = fDownscalingRates[multiplicity - 1];
         if (getNormalizedRandom() < rate)
         {
           saveEvent(event);

--- a/LargeBarrelAnalysis/Downscaler.cpp
+++ b/LargeBarrelAnalysis/Downscaler.cpp
@@ -1,0 +1,88 @@
+/**
+ *  @copyright Copyright 2022 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  @file Downscaler.cpp
+ */
+
+#include <iostream>
+#include <JPetOptionsTools/JPetOptionsTools.h>
+#include "Downscaler.h"
+
+using namespace jpet_options_tools;
+using namespace std;
+
+Downscaler::Downscaler(const char* name): JPetUserTask(name) {
+  std::random_device rd;
+  fRandomGenerator = std::mt19937(rd());
+}
+
+Downscaler::~Downscaler() {}
+
+bool Downscaler::init()
+{
+  INFO("Event downscaling started.");
+
+  // Parameter for back to back categorization
+  if (isOptionSet(fParams.getOptions(), fDownscalingRatesKey)){
+    fDownscalingRates = getOptionAsVectorOfDoubles(fParams.getOptions(), fDownscalingRatesKey);
+  } else {
+    WARNING("No downscaling rates provided by the user. All events will be passed on at a 100% rate.");
+  }
+
+  getStatistics().createHistogramWithAxes(new TH1D("filtered_event_multiplicity",
+                                                   "Number of hits in filtered events",
+                                                   20, 0.5, 20.5),
+                                          "Hits in Event", "Number of Hits");
+  
+  fOutputEvents = new JPetTimeWindow("JPetEvent");
+
+  return true;
+}
+
+bool Downscaler::exec()
+{
+  if (auto timeWindow = dynamic_cast<const JPetTimeWindow* const>(fEvent)) {
+    vector<JPetEvent> events;
+    for (uint i = 0; i < timeWindow->getNumberOfEvents(); i++) {
+      const auto& event = dynamic_cast<const JPetEvent&>(timeWindow->operator[](i));
+
+      int multiplicity = event.getHits().size();
+      double rate = 1.0;
+      if (multiplicity <= fDownscalingRates.size()) {
+        rate = fDownscalingRates[multiplicity - 1] / 100.;
+        if (getNormalizedRandom() < rate) {
+          saveEvent(event);          
+        }
+      } else { // rate not specified for this multiplicity
+        saveEvent(event);
+      }
+    }
+
+  } else { return false; }
+  return true;
+}
+
+bool Downscaler::terminate()
+{
+  INFO("Event downscaling completed.");
+  return true;
+}
+
+double Downscaler::getNormalizedRandom() {
+  return fRandomDistribution(fRandomGenerator);
+}
+
+void Downscaler::saveEvent(const JPetEvent &event) {
+
+  getStatistics().fillHistogram("filtered_event_multiplicity", event.getHits().size());
+  fOutputEvents->add<JPetEvent>(event);  
+}

--- a/LargeBarrelAnalysis/Downscaler.cpp
+++ b/LargeBarrelAnalysis/Downscaler.cpp
@@ -13,66 +13,68 @@
  *  @file Downscaler.cpp
  */
 
-#include <iostream>
-#include <JPetOptionsTools/JPetOptionsTools.h>
 #include "Downscaler.h"
+#include <JPetOptionsTools/JPetOptionsTools.h>
+#include <iostream>
 
 using namespace jpet_options_tools;
 using namespace std;
 
-Downscaler::Downscaler(const char* name): JPetUserTask(name) {
+Downscaler::Downscaler(const char *name) : JPetUserTask(name) {
   std::random_device rd;
   fRandomGenerator = std::mt19937(rd());
 }
 
 Downscaler::~Downscaler() {}
 
-bool Downscaler::init()
-{
+bool Downscaler::init() {
   INFO("Event downscaling started.");
 
   // Parameter for back to back categorization
-  if (isOptionSet(fParams.getOptions(), fDownscalingRatesKey)){
-    fDownscalingRates = getOptionAsVectorOfDoubles(fParams.getOptions(), fDownscalingRatesKey);
+  if (isOptionSet(fParams.getOptions(), fDownscalingRatesKey)) {
+    fDownscalingRates =
+        getOptionAsVectorOfDoubles(fParams.getOptions(), fDownscalingRatesKey);
   } else {
-    WARNING("No downscaling rates provided by the user. All events will be passed on at a 100% rate.");
+    WARNING("No downscaling rates provided by the user. All events will be "
+            "passed on at a 100% rate.");
   }
 
-  getStatistics().createHistogramWithAxes(new TH1D("filtered_event_multiplicity",
-                                                   "Number of hits in filtered events",
-                                                   20, 0.5, 20.5),
-                                          "Hits in Event", "Number of Hits");
-  
+  getStatistics().createHistogramWithAxes(
+      new TH1D("filtered_event_multiplicity",
+               "Number of hits in filtered events", 20, 0.5, 20.5),
+      "Hits in Event", "Number of Hits");
+
   fOutputEvents = new JPetTimeWindow("JPetEvent");
 
   return true;
 }
 
-bool Downscaler::exec()
-{
-  if (auto timeWindow = dynamic_cast<const JPetTimeWindow* const>(fEvent)) {
+bool Downscaler::exec() {
+  if (auto timeWindow = dynamic_cast<const JPetTimeWindow *const>(fEvent)) {
     vector<JPetEvent> events;
     for (uint i = 0; i < timeWindow->getNumberOfEvents(); i++) {
-      const auto& event = dynamic_cast<const JPetEvent&>(timeWindow->operator[](i));
+      const auto &event =
+          dynamic_cast<const JPetEvent &>(timeWindow->operator[](i));
 
       int multiplicity = event.getHits().size();
       double rate = 1.0;
       if (multiplicity <= fDownscalingRates.size()) {
         rate = fDownscalingRates[multiplicity - 1] / 100.;
         if (getNormalizedRandom() < rate) {
-          saveEvent(event);          
+          saveEvent(event);
         }
       } else { // rate not specified for this multiplicity
         saveEvent(event);
       }
     }
 
-  } else { return false; }
+  } else {
+    return false;
+  }
   return true;
 }
 
-bool Downscaler::terminate()
-{
+bool Downscaler::terminate() {
   INFO("Event downscaling completed.");
   return true;
 }
@@ -83,6 +85,7 @@ double Downscaler::getNormalizedRandom() {
 
 void Downscaler::saveEvent(const JPetEvent &event) {
 
-  getStatistics().fillHistogram("filtered_event_multiplicity", event.getHits().size());
-  fOutputEvents->add<JPetEvent>(event);  
+  getStatistics().fillHistogram("filtered_event_multiplicity",
+                                event.getHits().size());
+  fOutputEvents->add<JPetEvent>(event);
 }

--- a/LargeBarrelAnalysis/Downscaler.cpp
+++ b/LargeBarrelAnalysis/Downscaler.cpp
@@ -93,7 +93,6 @@ double Downscaler::getNormalizedRandom() { return fRandomDistribution(fRandomGen
 
 void Downscaler::saveEvent(const JPetEvent& event)
 {
-
   getStatistics().fillHistogram("filtered_event_multiplicity", event.getHits().size());
   fOutputEvents->add<JPetEvent>(event);
 }

--- a/LargeBarrelAnalysis/Downscaler.h
+++ b/LargeBarrelAnalysis/Downscaler.h
@@ -16,9 +16,9 @@
 #ifndef DOWNSCALER_H
 #define DOWNSCALER_H
 
-#include <random>
-#include <JPetUserTask/JPetUserTask.h>
 #include <JPetEvent/JPetEvent.h>
+#include <JPetUserTask/JPetUserTask.h>
+#include <random>
 
 class JPetWriter;
 
@@ -26,29 +26,31 @@ class JPetWriter;
  * @brief User Task filtering JPetEvent-s according to downscaling rules
  *
  * This task acts as a simple filter on a steam of JPetEvent objects.
- * Its operation is controlled by user options speficying separate 
+ * Its operation is controlled by user options speficying separate
  * "downscaling factors" for each multiplicity of hits in an event.
- * Each kind of events (1-hit, 2-hit, 3-hit events etc.) is either 
+ * Each kind of events (1-hit, 2-hit, 3-hit events etc.) is either
  * passed on entirely (if factor=100%) or downscaled (factor < 100%)
  * in order to reduce the volume of the files occupied by events
  * for which the full statistics from the data is not needed.
  *
  */
-class Downscaler : public JPetUserTask{
+class Downscaler : public JPetUserTask {
 public:
-	Downscaler(const char * name);
-	virtual ~Downscaler();
-	virtual bool init() override;
-	virtual bool exec() override;
-	virtual bool terminate() override;
+  Downscaler(const char *name);
+  virtual ~Downscaler();
+  virtual bool init() override;
+  virtual bool exec() override;
+  virtual bool terminate() override;
 
 protected:
-  const std::string fDownscalingRatesKey = "Downscaler_DownscalingRates_std::vector<double>";
+  const std::string fDownscalingRatesKey =
+      "Downscaler_DownscalingRates_std::vector<double>";
   std::vector<double> fDownscalingRates;
   std::mt19937 fRandomGenerator;
-  std::uniform_real_distribution<double> fRandomDistribution = std::uniform_real_distribution<double>(0.0, 1.0);
+  std::uniform_real_distribution<double> fRandomDistribution =
+      std::uniform_real_distribution<double>(0.0, 1.0);
 
-  void saveEvent(const JPetEvent& event);
+  void saveEvent(const JPetEvent &event);
   double getNormalizedRandom();
 };
 #endif /* !DOWNSCALER_H */

--- a/LargeBarrelAnalysis/Downscaler.h
+++ b/LargeBarrelAnalysis/Downscaler.h
@@ -1,0 +1,54 @@
+/**
+ *  @copyright Copyright 2022 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  @file Downscaler.h
+ */
+
+#ifndef DOWNSCALER_H
+#define DOWNSCALER_H
+
+#include <random>
+#include <JPetUserTask/JPetUserTask.h>
+#include <JPetEvent/JPetEvent.h>
+
+class JPetWriter;
+
+/**
+ * @brief User Task filtering JPetEvent-s according to downscaling rules
+ *
+ * This task acts as a simple filter on a steam of JPetEvent objects.
+ * Its operation is controlled by user options speficying separate 
+ * "downscaling factors" for each multiplicity of hits in an event.
+ * Each kind of events (1-hit, 2-hit, 3-hit events etc.) is either 
+ * passed on entirely (if factor=100%) or downscaled (factor < 100%)
+ * in order to reduce the volume of the files occupied by events
+ * for which the full statistics from the data is not needed.
+ *
+ */
+class Downscaler : public JPetUserTask{
+public:
+	Downscaler(const char * name);
+	virtual ~Downscaler();
+	virtual bool init() override;
+	virtual bool exec() override;
+	virtual bool terminate() override;
+
+protected:
+  const std::string fDownscalingRatesKey = "Downscaler_DownscalingRates_std::vector<double>";
+  std::vector<double> fDownscalingRates;
+  std::mt19937 fRandomGenerator;
+  std::uniform_real_distribution<double> fRandomDistribution = std::uniform_real_distribution<double>(0.0, 1.0);
+
+  void saveEvent(const JPetEvent& event);
+  double getNormalizedRandom();
+};
+#endif /* !DOWNSCALER_H */

--- a/LargeBarrelAnalysis/Downscaler.h
+++ b/LargeBarrelAnalysis/Downscaler.h
@@ -34,23 +34,22 @@ class JPetWriter;
  * for which the full statistics from the data is not needed.
  *
  */
-class Downscaler : public JPetUserTask {
+class Downscaler : public JPetUserTask
+{
 public:
-  Downscaler(const char *name);
+  Downscaler(const char* name);
   virtual ~Downscaler();
   virtual bool init() override;
   virtual bool exec() override;
   virtual bool terminate() override;
 
 protected:
-  const std::string fDownscalingRatesKey =
-      "Downscaler_DownscalingRates_std::vector<double>";
+  const std::string fDownscalingRatesKey = "Downscaler_DownscalingRates_std::vector<double>";
   std::vector<double> fDownscalingRates;
   std::mt19937 fRandomGenerator;
-  std::uniform_real_distribution<double> fRandomDistribution =
-      std::uniform_real_distribution<double>(0.0, 1.0);
+  std::uniform_real_distribution<double> fRandomDistribution = std::uniform_real_distribution<double>(0.0, 1.0);
 
-  void saveEvent(const JPetEvent &event);
+  void saveEvent(const JPetEvent& event);
   double getNormalizedRandom();
 };
 #endif /* !DOWNSCALER_H */

--- a/LargeBarrelAnalysis/Downscaler.h
+++ b/LargeBarrelAnalysis/Downscaler.h
@@ -20,8 +20,6 @@
 #include <JPetUserTask/JPetUserTask.h>
 #include <random>
 
-class JPetWriter;
-
 /**
  * @brief User Task filtering JPetEvent-s according to downscaling rules
  *

--- a/LargeBarrelAnalysis/PARAMETERS.md
+++ b/LargeBarrelAnalysis/PARAMETERS.md
@@ -78,6 +78,12 @@ time window for grouping hits in one event. Default value `5 000 ps`
 - `EventFinder_MinEventMultiplicity_int`  
 events of minimum multiplicity will only be saved in output file. Default value is 1, so all events are saved.
 
+- `Downscaler_DownscalingRates_std::vector<double>`__
+Set of downscaling rates for 1-hit, 2-hit, 3-hit events etc., expressed in per-cent. 
+If the Downscaler module is used, it will only pass the percentages of particular kinds of events (distinguished by number of hits in an event) according to the rates from this vector.
+For events with number of hits greater than the number of elements in this vector, rates of 100% will be assumed.
+For example, `[]` means the Downscaler will pass on all of the events; `[5.0, 10.0]` means that only 5% of 1-hit events and 10% of 2-hit events will be kept in the files while keeping 100% of events with 3 and more hits.
+
 - `Scatter_Categorizer_TOF_TimeDiff_float`  
 categorizer tool for recognizing scatterings. User can constrain allowed discrepancy between calculated time of flight of scatter candidate and difference of two hit times. Default value `2000 ps`
 

--- a/LargeBarrelAnalysis/PARAMETERS.md
+++ b/LargeBarrelAnalysis/PARAMETERS.md
@@ -78,7 +78,7 @@ time window for grouping hits in one event. Default value `5 000 ps`
 - `EventFinder_MinEventMultiplicity_int`  
 events of minimum multiplicity will only be saved in output file. Default value is 1, so all events are saved.
 
-- `Downscaler_DownscalingRates_std::vector<double>`__
+- `Downscaler_DownscalingRates_std::vector<double>`  
 Set of downscaling rates for 1-hit, 2-hit, 3-hit events etc., expressed in per-cent. 
 If the Downscaler module is used, it will only pass the percentages of particular kinds of events (distinguished by number of hits in an event) according to the rates from this vector.
 For events with number of hits greater than the number of elements in this vector, rates of 100% will be assumed.

--- a/LargeBarrelAnalysis/main.cpp
+++ b/LargeBarrelAnalysis/main.cpp
@@ -24,9 +24,11 @@
 
 using namespace std;
 
-int main(int argc, const char *argv[]) {
-  try {
-    JPetManager &manager = JPetManager::getManager();
+int main(int argc, const char* argv[])
+{
+  try
+  {
+    JPetManager& manager = JPetManager::getManager();
 
     manager.registerTask<TimeWindowCreator>("TimeWindowCreator");
     manager.registerTask<SignalFinder>("SignalFinder");
@@ -45,9 +47,10 @@ int main(int argc, const char *argv[]) {
     manager.useTask("EventCategorizer", "presel.evt", "cat.evt");
 
     manager.run(argc, argv);
-  } catch (const std::exception &except) {
-    std::cerr << "Unrecoverable error occured:" << except.what()
-              << "Exiting the program!" << std::endl;
+  }
+  catch (const std::exception& except)
+  {
+    std::cerr << "Unrecoverable error occured:" << except.what() << "Exiting the program!" << std::endl;
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/LargeBarrelAnalysis/main.cpp
+++ b/LargeBarrelAnalysis/main.cpp
@@ -20,6 +20,7 @@
 #include "SignalFinder.h"
 #include "EventFinder.h"
 #include "HitFinder.h"
+#include "Downscaler.h"
 
 using namespace std;
 
@@ -32,14 +33,16 @@ int main(int argc, const char* argv[]) {
     manager.registerTask<SignalTransformer>("SignalTransformer");
     manager.registerTask<HitFinder>("HitFinder");
     manager.registerTask<EventFinder>("EventFinder");
+    manager.registerTask<Downscaler>("Downscaler");
     manager.registerTask<EventCategorizer>("EventCategorizer");
-
+    
     manager.useTask("TimeWindowCreator", "hld", "tslot.calib");
     manager.useTask("SignalFinder", "tslot.calib", "raw.sig");
     manager.useTask("SignalTransformer", "raw.sig", "phys.sig");
     manager.useTask("HitFinder", "phys.sig", "hits");
     manager.useTask("EventFinder", "hits", "unk.evt");
-    manager.useTask("EventCategorizer", "unk.evt", "cat.evt");
+    manager.useTask("Downscaler", "unk.evt", "presel.evt");
+    manager.useTask("EventCategorizer", "presel.evt", "cat.evt");
 
     manager.run(argc, argv);
   } catch (const std::exception& except) {

--- a/LargeBarrelAnalysis/main.cpp
+++ b/LargeBarrelAnalysis/main.cpp
@@ -13,20 +13,20 @@
  *  @file main.cpp
  */
 
-#include <JPetManager/JPetManager.h>
-#include "TimeWindowCreator.h"
-#include "SignalTransformer.h"
+#include "Downscaler.h"
 #include "EventCategorizer.h"
-#include "SignalFinder.h"
 #include "EventFinder.h"
 #include "HitFinder.h"
-#include "Downscaler.h"
+#include "SignalFinder.h"
+#include "SignalTransformer.h"
+#include "TimeWindowCreator.h"
+#include <JPetManager/JPetManager.h>
 
 using namespace std;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
   try {
-    JPetManager& manager = JPetManager::getManager();
+    JPetManager &manager = JPetManager::getManager();
 
     manager.registerTask<TimeWindowCreator>("TimeWindowCreator");
     manager.registerTask<SignalFinder>("SignalFinder");
@@ -35,7 +35,7 @@ int main(int argc, const char* argv[]) {
     manager.registerTask<EventFinder>("EventFinder");
     manager.registerTask<Downscaler>("Downscaler");
     manager.registerTask<EventCategorizer>("EventCategorizer");
-    
+
     manager.useTask("TimeWindowCreator", "hld", "tslot.calib");
     manager.useTask("SignalFinder", "tslot.calib", "raw.sig");
     manager.useTask("SignalTransformer", "raw.sig", "phys.sig");
@@ -45,8 +45,9 @@ int main(int argc, const char* argv[]) {
     manager.useTask("EventCategorizer", "presel.evt", "cat.evt");
 
     manager.run(argc, argv);
-  } catch (const std::exception& except) {
-    std::cerr << "Unrecoverable error occured:" << except.what() << "Exiting the program!" << std::endl;
+  } catch (const std::exception &except) {
+    std::cerr << "Unrecoverable error occured:" << except.what()
+              << "Exiting the program!" << std::endl;
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;


### PR DESCRIPTION
This PR adds the "Downscaler" module to LargeBarrelAnalysis.

"Downscaler" is a simple filtering module which randomly accepts events with certain number of hits at certain rates provided by the user using the `Downscaler_DownscalingRates_std::vector<double>` parameter (see the changes in `PARAMETERS.md` for its interpretation).

The module is needed for the upcoming Run 11 preselection.

By the way, this PR adds the previously-missing `.clang-format` file (same as in j-pet-framework) to the repository root dir.