### PR TITLE
Fix for the automated installation script: do not fail on unbound variable

### DIFF
--- a/scripts/get-me-a-jpet-framework.sh
+++ b/scripts/get-me-a-jpet-framework.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set -u
 set -o pipefail
 
 


### PR DESCRIPTION
The installation script needs to source thisframework.sh which relies on the possibility of $FRAMEWORKSYS being undefined. Setting 'set -u' in the calling script propagated to thisframework.sh causing it to fail during automated installation in environments where thisframework was never sourced before.

The latter was the reason why I never discovered this problem before (I practically always have FRAMEWORKSYS set to something already). However, the failure during automated installation was reported to me by several users.