### PR TITLE
TOT converter only when requested

### DIFF
--- a/LargeBarrelAnalysis/HitFinder.cpp
+++ b/LargeBarrelAnalysis/HitFinder.cpp
@@ -112,6 +112,7 @@ bool HitFinder::init()
     else
     {
       INFO("Hit finder will not convert ToT to deposited energy since no user parameters are provided.");
+      fToTConverterFactory.setNullObject(true);
     }
   }
   // Loading parameters for TOT synchronizationi
@@ -159,8 +160,7 @@ bool HitFinder::exec()
   if (auto& timeWindow = dynamic_cast<const JPetTimeWindow* const>(fEvent))
   {
     auto signalsBySlot = HitFinderTools::getSignalsBySlot(timeWindow, fUseCorruptedSignals);
-    auto totConverter = fToTConverterFactory.getEnergyConverter();
-    auto allHits = HitFinderTools::matchAllSignals(signalsBySlot, fVelocities, fABTimeDiff, fRefDetScinID, fConvertToT, totConverter, getStatistics(),
+    auto allHits = HitFinderTools::matchAllSignals(signalsBySlot, fVelocities, fABTimeDiff, fRefDetScinID, fToTConverterFactory, getStatistics(),
                                                    fSaveControlHistos);
     if (fSaveControlHistos)
     {
@@ -194,7 +194,7 @@ void HitFinder::saveHits(const std::vector<JPetHit>& hits)
       // synchronization
       if (fSyncToT)
       {
-	//ToDo change getEnergy() to getTOT() once implemented
+        // ToDo change getEnergy() to getTOT() once implemented
         getStatistics().fillHistogram("SyncTOT_all_hits", hit.getEnergy());
       }
       getStatistics().fillHistogram("TOT_all_hits", tot);

--- a/LargeBarrelAnalysis/HitFinderTools.h
+++ b/LargeBarrelAnalysis/HitFinderTools.h
@@ -16,7 +16,7 @@
 #ifndef HITFINDERTOOLS_H
 #define HITFINDERTOOLS_H
 
-#include "ToTEnergyConverter.h"
+#include "ToTEnergyConverterFactory.h"
 #include <JPetHit/JPetHit.h>
 #include <JPetStatistics/JPetStatistics.h>
 #include <JPetTimeWindow/JPetTimeWindow.h>
@@ -44,14 +44,13 @@ public:
   static std::map<int, std::vector<JPetPhysSignal>> getSignalsBySlot(const JPetTimeWindow* timeWindow, bool useCorrupts);
   static std::vector<JPetHit> matchAllSignals(std::map<int, std::vector<JPetPhysSignal>>& allSignals,
                                               const std::map<unsigned int, std::vector<double>>& velocitiesMap, double timeDiffAB, int refDetScinId,
-                                              bool convertToT, const tot_energy_converter::ToTEnergyConverter& totConverter, JPetStatistics& stats,
-                                              bool saveHistos);
+                                              const ToTEnergyConverterFactory& totEnergyConverterFactory, JPetStatistics& stats, bool saveHistos);
   static std::vector<JPetHit> matchSignals(std::vector<JPetPhysSignal>& slotSignals, const std::map<unsigned int, std::vector<double>>& velocitiesMap,
-                                           double timeDiffAB, bool convertToT, const tot_energy_converter::ToTEnergyConverter& totConverter,
-                                           JPetStatistics& stats, bool saveHistos);
+                                           double timeDiffAB, const ToTEnergyConverterFactory& totEnergyConverterFactory, JPetStatistics& stats,
+                                           bool saveHistos);
   static JPetHit createHit(const JPetPhysSignal& signal1, const JPetPhysSignal& signal2,
-                           const std::map<unsigned int, std::vector<double>>& velocitiesMap, bool convertToT,
-                           const tot_energy_converter::ToTEnergyConverter& totConverter, JPetStatistics& stats, bool saveHistos);
+                           const std::map<unsigned int, std::vector<double>>& velocitiesMap,
+                           const ToTEnergyConverterFactory& totEnergyConverterFactory, JPetStatistics& stats, bool saveHistos);
   static JPetHit createDummyRefDetHit(const JPetPhysSignal& signal);
   static int getProperChannel(const JPetPhysSignal& signal);
   static void checkTheta(const double& theta);

--- a/LargeBarrelAnalysis/PARAMETERS.md
+++ b/LargeBarrelAnalysis/PARAMETERS.md
@@ -97,9 +97,11 @@ denotes Time over Threshold cut minimal value for simple selection of deexcitati
 denotes Time over Threshold cut maximal value for simple selection of deexcitation photons. Default value: `50 000 ps`
 
 - TOT to energy conversion parameters:  
+`HitFinder_ConvertToT_bool`  
+Set `true` to initialise the parameters for TOT/Edep conversion, by default `false`.  
 `ToTEnergyConverterFactory_ToT2EnergyFunction_std::string`  
 String with function formula in ROOT format  
-See documentation of [TFormula class](https://root.cern.ch/doc/master/classTFormula.html)
+See documentation of [TFormula class](https://root.cern.ch/doc/master/classTFormula.html)  
 `ToTEnergyConverterFactory_ToT2EnergyParameters_std::vector<double>`  
 Array of parameters for function above, given as a vector of doubles  
 `ToTEnergyConverterFactory_ToT2EnergyFunctionLimits_std::vector<double>`  

--- a/LargeBarrelAnalysis/ToTEnergyConverter.cpp
+++ b/LargeBarrelAnalysis/ToTEnergyConverter.cpp
@@ -22,13 +22,14 @@ using FunctionLimits = std::pair<double, double>;
 using FunctionParams = std::vector<double>;
 using FuncParamsAndLimits = std::pair<FunctionFormula, std::pair<FunctionParams, FunctionLimits>>;
 
-namespace tot_energy_converter {
+namespace tot_energy_converter
+{
 
 ToTEnergyConverter::ToTEnergyConverter(const ToTEParams& params, const ToTERange range) : fFunction(params, range) {}
 
 double ToTEnergyConverter::operator()(double x) const { return fFunction(x); }
 
-std::pair<double, double> ToTEnergyConverter::getRange() const { return {fFunction.getRange().fMin, fFunction.getRange().fMax }; }
+std::pair<double, double> ToTEnergyConverter::getRange() const { return {fFunction.getRange().fMin, fFunction.getRange().fMax}; }
 
 ToTEnergyConverter generateToTEnergyConverter(const FuncParamsAndLimits& formula)
 {
@@ -40,4 +41,4 @@ ToTEnergyConverter generateToTEnergyConverter(const FuncParamsAndLimits& formula
   ToTEnergyConverter conv(params, Range(100000, funcLimits.first, funcLimits.second));
   return conv;
 }
-}
+} // namespace tot_energy_converter

--- a/LargeBarrelAnalysis/ToTEnergyConverter.h
+++ b/LargeBarrelAnalysis/ToTEnergyConverter.h
@@ -31,14 +31,13 @@ public:
   ToTEnergyConverter(const ToTEParams& params, ToTERange);
   double operator()(double val) const;
   /// Function returns the range of arguments for which the converter is valid
-  std::pair<double, double> getRange() const; 
+  std::pair<double, double> getRange() const;
 
 private:
   CachedFunction fFunction;
 };
 
-ToTEnergyConverter generateToTEnergyConverter(
-  const std::pair<std::string, std::pair<std::vector<double>, std::pair<double, double>>>& formula);
-}
+ToTEnergyConverter generateToTEnergyConverter(const std::pair<std::string, std::pair<std::vector<double>, std::pair<double, double>>>& formula);
+} // namespace tot_energy_converter
 
 #endif /* !TOTENERGYCONVERTER_H */

--- a/LargeBarrelAnalysis/ToTEnergyConverterFactory.cpp
+++ b/LargeBarrelAnalysis/ToTEnergyConverterFactory.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2020 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2023 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -76,7 +76,27 @@ void ToTEnergyConverterFactory::loadConverterOptions(const ToTEnergyConverterFac
   {
     fToT2EnergyAll = {toT2EnergyFormula, {toT2EnergyParameters, {}}};
   }
+
+  /// Converter factory by default is null, only after proper initialisation
+  /// the flag is changed to true and can be used in the examples
+  fIsNullObject = false;
 }
+
+void ToTEnergyConverterFactory::setEnergyConverterOptions(const FuncParamsAndLimits formula)
+{
+  fEnergy2ToTAll = formula;
+  fIsNullObject = false;
+}
+
+void ToTEnergyConverterFactory::setToTConverterOptions(const FuncParamsAndLimits formula)
+{
+  fToT2EnergyAll = formula;
+  fIsNullObject = false;
+}
+
+void ToTEnergyConverterFactory::setNullObject(bool isNull) { fIsNullObject = isNull; }
+
+bool ToTEnergyConverterFactory::isNullObject() const { return fIsNullObject; }
 
 tot_energy_converter::ToTEnergyConverter ToTEnergyConverterFactory::getToTConverter() const { return generateToTEnergyConverter(fEnergy2ToTAll); }
 

--- a/LargeBarrelAnalysis/ToTEnergyConverterFactory.h
+++ b/LargeBarrelAnalysis/ToTEnergyConverterFactory.h
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2020 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2023 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -35,8 +35,13 @@ public:
   ToTEnergyConverterFactory& operator=(ToTEnergyConverterFactory const&) = delete;
 
   void loadConverterOptions(const ConverterOptions& opts);
+  void setEnergyConverterOptions(const FuncParamsAndLimits formula);
+  void setToTConverterOptions(const FuncParamsAndLimits formula);
   tot_energy_converter::ToTEnergyConverter getToTConverter() const;
   tot_energy_converter::ToTEnergyConverter getEnergyConverter() const;
+
+  void setNullObject(bool isNull);
+  bool isNullObject() const;
 
 private:
   const std::string kEnergy2ToTParametersParamKey = "ToTEnergyConverterFactory_Energy2ToTParameters_std::vector<double>";
@@ -49,6 +54,9 @@ private:
 
   FuncParamsAndLimits fEnergy2ToTAll;
   FuncParamsAndLimits fToT2EnergyAll;
+
+  /// By default null, has to be initialised with parameters
+  bool fIsNullObject = true;
 };
 
 #endif /* !TOTENERGYCONVERTERFACTORY_H */

--- a/LargeBarrelAnalysis/tests/CMakeLists.txt
+++ b/LargeBarrelAnalysis/tests/CMakeLists.txt
@@ -50,12 +50,12 @@ foreach(test_source IN ITEMS ${UNIT_TEST_SOURCES})
       # TimeWindowCreatorToolsTests requires UniversalFileLoader
       package_add_test(${test} ${test_source} ../UniversalFileLoader.cpp)
     elseif(${test} MATCHES HitFinderToolsTest)
-      # HitFinderToolsTest requires UniversalFileLoader and ToTEnergyConverter
-      package_add_test(${test} ${test_source} ../UniversalFileLoader.cpp ../ToTEnergyConverter.cpp)
+      # HitFinderToolsTest requires UniversalFileLoader and ToTEnergyConverter and ToTEnergyConverterFactory
+      package_add_test(${test} ${test_source} ../UniversalFileLoader.cpp ../ToTEnergyConverter.cpp ../ToTEnergyConverterFactory.cpp)
     elseif(${test} MATCHES ToTEnergyConverterFactoryTest)
       package_add_test(${test} ${test_source} ../ToTEnergyConverter.cpp)
     elseif(${test} MATCHES EventCategorizerToolsTest)
-      package_add_test(${test} ${test_source} ../HitFinderTools.cpp ../UniversalFileLoader.cpp ../ToTEnergyConverter.cpp)
+      package_add_test(${test} ${test_source} ../HitFinderTools.cpp ../UniversalFileLoader.cpp ../ToTEnergyConverter.cpp ../ToTEnergyConverterFactory.cpp)
     else()
       package_add_test(${test} ${test_source})
     endif(${test} MATCHES TimeWindowCreatorToolsTest)

--- a/LargeBarrelAnalysis/tests/HitFinderToolsTest.cpp
+++ b/LargeBarrelAnalysis/tests/HitFinderToolsTest.cpp
@@ -155,9 +155,6 @@ BOOST_AUTO_TEST_CASE(matchAllSignals_test_refDetID)
   JPetStatistics stats;
   std::map<unsigned int, std::vector<double>> velocitiesMap;
 
-  // JPetCachedFunctionParams params("pol1", {0.0, 10.0});
-  // ToTEnergyConverter conv(params, Range(10000, 0., 100.));
-
   FunctionFormula formula1 = "pol1";
   FunctionParams params1 = {-91958, 19341};
   FunctionLimits limits1 = {0, 100};
@@ -183,295 +180,320 @@ BOOST_AUTO_TEST_CASE(matchAllSignals_test_refDetID)
 
 BOOST_AUTO_TEST_CASE(createHit_test)
 {
-  // JPetLayer layer1(1, true, "layer1", 10.0);
-  // JPetBarrelSlot slot1(2, true, "barel1", 30.0, 23);
-  // slot1.setLayer(layer1);
-  //
-  // JPetScin scin1(1);
-  // scin1.setBarrelSlot(slot1);
-  //
-  // JPetPM pmA(11, "first"), pmB(22, "second");
-  // pmA.setScin(scin1);
-  // pmB.setScin(scin1);
-  // pmA.setBarrelSlot(slot1);
-  // pmB.setBarrelSlot(slot1);
-  // pmA.setSide(JPetPM::SideA);
-  // pmB.setSide(JPetPM::SideB);
-  //
-  // JPetTOMBChannel channel1(66), channel2(88);
-  // JPetSigCh sigCh1L(JPetSigCh::Leading, 10.0);
-  // JPetSigCh sigCh1T(JPetSigCh::Trailing, 12.0);
-  // JPetSigCh sigCh2L(JPetSigCh::Leading, 11.0);
-  // JPetSigCh sigCh2T(JPetSigCh::Trailing, 13.0);
-  // sigCh1L.setTOMBChannel(channel1);
-  // sigCh1T.setTOMBChannel(channel1);
-  // sigCh2L.setTOMBChannel(channel2);
-  // sigCh2T.setTOMBChannel(channel2);
-  // sigCh1L.setThresholdNumber(1);
-  // sigCh1T.setThresholdNumber(1);
-  // sigCh2L.setThresholdNumber(1);
-  // sigCh2T.setThresholdNumber(1);
-  // sigCh1L.setPM(pmA);
-  // sigCh1T.setPM(pmA);
-  // sigCh2L.setPM(pmB);
-  // sigCh2T.setPM(pmB);
-  //
-  // JPetRawSignal raw1, raw2;
-  // raw1.addPoint(sigCh1L);
-  // raw1.addPoint(sigCh1T);
-  // raw2.addPoint(sigCh2L);
-  // raw2.addPoint(sigCh2T);
-  // raw1.setBarrelSlot(slot1);
-  // raw2.setBarrelSlot(slot1);
-  // raw1.setPM(pmA);
-  // raw2.setPM(pmB);
-  //
-  // JPetRecoSignal reco1, reco2;
-  // reco1.setRawSignal(raw1);
-  // reco2.setRawSignal(raw2);
-  // reco1.setBarrelSlot(slot1);
-  // reco2.setBarrelSlot(slot1);
-  // reco1.setPM(pmA);
-  // reco2.setPM(pmB);
-  //
-  // JPetPhysSignal physSigA, physSigB;
-  // physSigA.setTime(10.0);
-  // physSigB.setTime(12.0);
-  // physSigA.setRecoSignal(reco1);
-  // physSigB.setRecoSignal(reco2);
-  //
-  // std::map<unsigned int, std::vector<double>> velocitiesMap;
-  // std::vector<double> velVec = {2.0, 3.4, 4.5, 5.6};
-  // velocitiesMap.insert(std::make_pair(66, velVec));
-  // velocitiesMap.insert(std::make_pair(88, velVec));
-  //
-  // JPetStatistics stats;
-  //
-  // JPetCachedFunctionParams params1("pol1", {0.0, 10.0});
-  // ToTEnergyConverter conv1(params1, Range(10000, 0., 100.));
-  //
-  // auto hit1 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, true, conv1, stats, false);
-  //
-  // auto epsilon = 0.0001;
-  //
-  // BOOST_REQUIRE_CLOSE(hit1.getTime(), 11.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getQualityOfTime(), -1.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getTimeDiff(), 2.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getQualityOfTimeDiff(), -1.0, epsilon);
-  // BOOST_REQUIRE_EQUAL(hit1.getScintillator().getID(), 1);
-  // BOOST_REQUIRE_EQUAL(hit1.getBarrelSlot().getID(), 2);
-  // BOOST_REQUIRE_CLOSE(hit1.getPosX(), 10.0 * cos(TMath::DegToRad() * 30.0), epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getPosY(), 10.0 * sin(TMath::DegToRad() * 30.0), epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getPosZ(), 4.0 * 1.0 / 2000.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getEnergy(), 40.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(hit1.getQualityOfEnergy(), -1.0, epsilon);
-  //
-  // // Case: resultcan be caluculated but ToT is outside range of function
-  // JPetCachedFunctionParams params2("pol1", {0.0, 10.0});
-  // ToTEnergyConverter conv2(params2, Range(10000, 0., 1.));
-  //
-  // auto hit2 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, true, conv2, stats, false);
-  // BOOST_REQUIRE_CLOSE(hit2.getEnergy(), -1.0, epsilon);
-  //
-  // // Case with different function
-  // JPetCachedFunctionParams params3("sqrt([0]*x)", {1.0});
-  // ToTEnergyConverter conv3(params3, Range(10000, 0., 100.));
-  //
-  // auto hit3 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, true, conv3, stats, false);
-  // BOOST_REQUIRE_CLOSE(hit3.getEnergy(), 2, epsilon);
-  //
-  // // Case: result is -nan, energy set to -1.0
-  // JPetCachedFunctionParams params4("sqrt([0]*x)", {-1.0});
-  // ToTEnergyConverter conv4(params4, Range(10000, -100.0, 100.));
-  //
-  // auto hit4 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, true, conv4, stats, false);
-  // BOOST_REQUIRE_CLOSE(hit4.getEnergy(), -1.0, epsilon);
+  JPetLayer layer1(1, true, "layer1", 10.0);
+  JPetBarrelSlot slot1(2, true, "barel1", 30.0, 23);
+  slot1.setLayer(layer1);
+
+  JPetScin scin1(1);
+  scin1.setBarrelSlot(slot1);
+
+  JPetPM pmA(11, "first"), pmB(22, "second");
+  pmA.setScin(scin1);
+  pmB.setScin(scin1);
+  pmA.setBarrelSlot(slot1);
+  pmB.setBarrelSlot(slot1);
+  pmA.setSide(JPetPM::SideA);
+  pmB.setSide(JPetPM::SideB);
+
+  JPetTOMBChannel channel1(66), channel2(88);
+  JPetSigCh sigCh1L(JPetSigCh::Leading, 10.0);
+  JPetSigCh sigCh1T(JPetSigCh::Trailing, 12.0);
+  JPetSigCh sigCh2L(JPetSigCh::Leading, 11.0);
+  JPetSigCh sigCh2T(JPetSigCh::Trailing, 13.0);
+  sigCh1L.setTOMBChannel(channel1);
+  sigCh1T.setTOMBChannel(channel1);
+  sigCh2L.setTOMBChannel(channel2);
+  sigCh2T.setTOMBChannel(channel2);
+  sigCh1L.setThresholdNumber(1);
+  sigCh1T.setThresholdNumber(1);
+  sigCh2L.setThresholdNumber(1);
+  sigCh2T.setThresholdNumber(1);
+  sigCh1L.setPM(pmA);
+  sigCh1T.setPM(pmA);
+  sigCh2L.setPM(pmB);
+  sigCh2T.setPM(pmB);
+
+  JPetRawSignal raw1, raw2;
+  raw1.addPoint(sigCh1L);
+  raw1.addPoint(sigCh1T);
+  raw2.addPoint(sigCh2L);
+  raw2.addPoint(sigCh2T);
+  raw1.setBarrelSlot(slot1);
+  raw2.setBarrelSlot(slot1);
+  raw1.setPM(pmA);
+  raw2.setPM(pmB);
+
+  JPetRecoSignal reco1, reco2;
+  reco1.setRawSignal(raw1);
+  reco2.setRawSignal(raw2);
+  reco1.setBarrelSlot(slot1);
+  reco2.setBarrelSlot(slot1);
+  reco1.setPM(pmA);
+  reco2.setPM(pmB);
+
+  JPetPhysSignal physSigA, physSigB;
+  physSigA.setTime(10.0);
+  physSigB.setTime(12.0);
+  physSigA.setRecoSignal(reco1);
+  physSigB.setRecoSignal(reco2);
+
+  std::map<unsigned int, std::vector<double>> velocitiesMap;
+  std::vector<double> velVec = {2.0, 3.4, 4.5, 5.6};
+  velocitiesMap.insert(std::make_pair(66, velVec));
+  velocitiesMap.insert(std::make_pair(88, velVec));
+
+  JPetStatistics stats;
+
+  FunctionFormula formula1 = "pol1";
+  FunctionParams params1 = {0.0, 10.0};
+  FunctionLimits limits1 = {0., 100.};
+  FuncParamsAndLimits tot2e1 = {formula1, {params1, limits1}};
+  ToTEnergyConverterFactory fact1;
+  fact1.setToTConverterOptions(tot2e1);
+
+  auto hit1 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, fact1, stats, false);
+
+  auto epsilon = 0.0001;
+
+  BOOST_REQUIRE_CLOSE(hit1.getTime(), 11.0, epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getQualityOfTime(), -1.0, epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getTimeDiff(), 2.0, epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getQualityOfTimeDiff(), -1.0, epsilon);
+  BOOST_REQUIRE_EQUAL(hit1.getScintillator().getID(), 1);
+  BOOST_REQUIRE_EQUAL(hit1.getBarrelSlot().getID(), 2);
+  BOOST_REQUIRE_CLOSE(hit1.getPosX(), 10.0 * cos(TMath::DegToRad() * 30.0), epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getPosY(), 10.0 * sin(TMath::DegToRad() * 30.0), epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getPosZ(), 4.0 * 1.0 / 2000.0, epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getEnergy(), 40.0, epsilon);
+  BOOST_REQUIRE_CLOSE(hit1.getQualityOfEnergy(), -1.0, epsilon);
+
+  // Case: resultcan be caluculated but ToT is outside range of function
+  FunctionFormula formula2 = "pol1";
+  FunctionParams params2 = {0.0, 10.0};
+  FunctionLimits limits2 = {0., 1.};
+  FuncParamsAndLimits tot2e2 = {formula2, {params2, limits2}};
+  ToTEnergyConverterFactory fact2;
+  fact2.setToTConverterOptions(tot2e2);
+
+  auto hit2 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, fact2, stats, false);
+  BOOST_REQUIRE_CLOSE(hit2.getEnergy(), -1.0, epsilon);
+
+  // Case with different function
+  FunctionFormula formula3 = "sqrt([0]*x)";
+  FunctionParams params3 = {1.0};
+  FunctionLimits limits3 = {0.0, 100.0};
+  FuncParamsAndLimits tot2e3 = {formula3, {params3, limits3}};
+  ToTEnergyConverterFactory fact3;
+  fact3.setToTConverterOptions(tot2e3);
+
+  auto hit3 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, fact3, stats, false);
+  BOOST_REQUIRE_CLOSE(hit3.getEnergy(), 2, epsilon);
+
+  // Case: result is -nan, energy set to -1.0
+  FunctionFormula formula4 = "sqrt([0]*x)";
+  FunctionParams params4 = {-1.0};
+  FunctionLimits limits4 = {-100.0, 100.0};
+  FuncParamsAndLimits tot2e4 = {formula4, {params4, limits4}};
+  ToTEnergyConverterFactory fact4;
+  fact4.setToTConverterOptions(tot2e4);
+
+  auto hit4 = HitFinderTools::createHit(physSigA, physSigB, velocitiesMap, fact4, stats, false);
+  BOOST_REQUIRE_CLOSE(hit4.getEnergy(), -1.0, epsilon);
 }
 
 BOOST_AUTO_TEST_CASE(matchSignals_test_sameSide)
 {
-  // JPetBarrelSlot slot1(1, true, "one", 15.0, 1);
-  // JPetScin scin1(1);
-  // JPetPM pm1(11, "first");
-  // pm1.setBarrelSlot(slot1);
-  // pm1.setScin(scin1);
-  // pm1.setSide(JPetPM::SideA);
-  // JPetPhysSignal physSig1, physSig2, physSig3;
-  // physSig1.setBarrelSlot(slot1);
-  // physSig2.setBarrelSlot(slot1);
-  // physSig3.setBarrelSlot(slot1);
-  // physSig1.setPM(pm1);
-  // physSig2.setPM(pm1);
-  // physSig3.setPM(pm1);
-  // physSig1.setTime(1.0);
-  // physSig2.setTime(2.0);
-  // physSig3.setTime(3.0);
-  // std::vector<JPetPhysSignal> slotSignals;
-  // slotSignals.push_back(physSig1);
-  // slotSignals.push_back(physSig2);
-  // slotSignals.push_back(physSig3);
-  //
-  // JPetStatistics stats;
-  // std::map<unsigned int, std::vector<double>> velocitiesMap;
-  // JPetCachedFunctionParams params("pol1", {0.0, 10.0});
-  // ToTEnergyConverter conv(params, Range(10000, 0., 100.));
-  //
-  // auto result = HitFinderTools::matchSignals(slotSignals, velocitiesMap, 5.0, false, conv, stats, false);
-  // BOOST_REQUIRE(result.empty());
+  JPetBarrelSlot slot1(1, true, "one", 15.0, 1);
+  JPetScin scin1(1);
+  JPetPM pm1(11, "first");
+  pm1.setBarrelSlot(slot1);
+  pm1.setScin(scin1);
+  pm1.setSide(JPetPM::SideA);
+  JPetPhysSignal physSig1, physSig2, physSig3;
+  physSig1.setBarrelSlot(slot1);
+  physSig2.setBarrelSlot(slot1);
+  physSig3.setBarrelSlot(slot1);
+  physSig1.setPM(pm1);
+  physSig2.setPM(pm1);
+  physSig3.setPM(pm1);
+  physSig1.setTime(1.0);
+  physSig2.setTime(2.0);
+  physSig3.setTime(3.0);
+  std::vector<JPetPhysSignal> slotSignals;
+  slotSignals.push_back(physSig1);
+  slotSignals.push_back(physSig2);
+  slotSignals.push_back(physSig3);
+
+  JPetStatistics stats;
+  std::map<unsigned int, std::vector<double>> velocitiesMap;
+
+  FunctionFormula formula1 = "pol1";
+  FunctionParams params1 = {0.0, 10.0};
+  FunctionLimits limits1 = {0., 100.};
+  FuncParamsAndLimits tot2e1 = {formula1, {params1, limits1}};
+  ToTEnergyConverterFactory fact1;
+  fact1.setToTConverterOptions(tot2e1);
+
+  auto result = HitFinderTools::matchSignals(slotSignals, velocitiesMap, 5.0, fact1, stats, false);
+  BOOST_REQUIRE(result.empty());
 }
 
 BOOST_AUTO_TEST_CASE(matchSignals_test)
 {
-  // JPetLayer layer1(1, true, "layer1", 10.0);
-  // JPetBarrelSlot slot1(23, true, "barel1", 30.0, 23);
-  // slot1.setLayer(layer1);
-  //
-  // JPetScin scin1(23);
-  // scin1.setBarrelSlot(slot1);
-  // JPetPM pm1A(31, "1A");
-  // JPetPM pm1B(75, "1B");
-  // pm1A.setScin(scin1);
-  // pm1B.setScin(scin1);
-  // pm1A.setBarrelSlot(slot1);
-  // pm1B.setBarrelSlot(slot1);
-  // pm1A.setSide(JPetPM::SideA);
-  // pm1B.setSide(JPetPM::SideB);
-  //
-  // JPetTOMBChannel channel1(66);
-  // JPetTOMBChannel channel2(88);
-  // JPetSigCh sigCh1(JPetSigCh::Leading, 12.3);
-  // JPetSigCh sigCh2(JPetSigCh::Leading, 13.4);
-  // sigCh1.setTOMBChannel(channel1);
-  // sigCh2.setTOMBChannel(channel2);
-  // sigCh1.setThresholdNumber(1);
-  // sigCh2.setThresholdNumber(1);
-  // sigCh1.setPM(pm1A);
-  // sigCh2.setPM(pm1B);
-  //
-  // JPetRawSignal raw1;
-  // JPetRawSignal raw2;
-  // raw1.addPoint(sigCh1);
-  // raw2.addPoint(sigCh2);
-  // raw1.setBarrelSlot(slot1);
-  // raw2.setBarrelSlot(slot1);
-  //
-  // JPetRecoSignal reco1;
-  // JPetRecoSignal reco2;
-  // reco1.setRawSignal(raw1);
-  // reco2.setRawSignal(raw2);
-  // reco1.setBarrelSlot(slot1);
-  // reco2.setBarrelSlot(slot1);
-  //
-  // JPetPhysSignal physSig1A, physSig1B;
-  // JPetPhysSignal physSig2A, physSig2B;
-  // JPetPhysSignal physSig3A, physSig3B;
-  // JPetPhysSignal physSigA;
-  // physSigA.setBarrelSlot(slot1);
-  // physSig1A.setBarrelSlot(slot1);
-  // physSig1B.setBarrelSlot(slot1);
-  // physSig2A.setBarrelSlot(slot1);
-  // physSig2B.setBarrelSlot(slot1);
-  // physSig3A.setBarrelSlot(slot1);
-  // physSig3B.setBarrelSlot(slot1);
-  // physSigA.setRecoSignal(reco1);
-  // physSig1A.setRecoSignal(reco1);
-  // physSig2A.setRecoSignal(reco1);
-  // physSig3A.setRecoSignal(reco1);
-  // physSig1B.setRecoSignal(reco2);
-  // physSig2B.setRecoSignal(reco2);
-  // physSig3B.setRecoSignal(reco2);
-  // physSigA.setPM(pm1A);
-  // physSig1A.setPM(pm1A);
-  // physSig1B.setPM(pm1B);
-  // physSig2A.setPM(pm1A);
-  // physSig2B.setPM(pm1B);
-  // physSig3A.setPM(pm1A);
-  // physSig3B.setPM(pm1B);
-  // physSig1A.setTime(1.0);
-  // physSig1B.setTime(1.5);
-  // physSigA.setTime(2.2);
-  // physSig2A.setTime(4.0);
-  // physSig2B.setTime(4.8);
-  // physSig3A.setTime(7.2);
-  // physSig3B.setTime(6.5);
-  // physSigA.setRecoFlag(JPetBaseSignal::Good);
-  // physSig1A.setRecoFlag(JPetBaseSignal::Good);
-  // physSig1B.setRecoFlag(JPetBaseSignal::Good);
-  // physSig2A.setRecoFlag(JPetBaseSignal::Good);
-  // physSig2B.setRecoFlag(JPetBaseSignal::Corrupted);
-  // physSig3A.setRecoFlag(JPetBaseSignal::Good);
-  // physSig3B.setRecoFlag(JPetBaseSignal::Good);
-  // std::vector<JPetPhysSignal> slotSignals;
-  // slotSignals.push_back(physSigA);
-  // slotSignals.push_back(physSig1A);
-  // slotSignals.push_back(physSig1B);
-  // slotSignals.push_back(physSig2A);
-  // slotSignals.push_back(physSig2B);
-  // slotSignals.push_back(physSig3A);
-  // slotSignals.push_back(physSig3B);
-  //
-  // JPetStatistics stats;
-  // std::map<unsigned int, std::vector<double>> velocitiesMap;
-  // std::vector<double> velVec = {2.0, 3.4, 4.5, 5.6};
-  // velocitiesMap.insert(std::make_pair(66, velVec));
-  // velocitiesMap.insert(std::make_pair(88, velVec));
-  //
-  // JPetCachedFunctionParams params("pol1", {0.0, 10.0});
-  // ToTEnergyConverter conv(params, Range(10000, 0., 100.));
-  //
-  // auto result = HitFinderTools::matchSignals(slotSignals, velocitiesMap, 1.0, false, conv, stats, false);
-  // auto epsilon = 0.0001;
-  //
-  // BOOST_REQUIRE_EQUAL(result.size(), 3);
-  //
-  // BOOST_REQUIRE_EQUAL(result.at(0).getSignalA().getPM().getID(), 31);
-  // BOOST_REQUIRE_EQUAL(result.at(0).getSignalB().getPM().getID(), 75);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getSignalA().getPM().getID(), 31);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getSignalB().getPM().getID(), 75);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getSignalA().getPM().getID(), 31);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getSignalB().getPM().getID(), 75);
-  //
-  // BOOST_REQUIRE_EQUAL(result.at(0).getSignalA().getRecoFlag(), JPetBaseSignal::Good);
-  // BOOST_REQUIRE_EQUAL(result.at(0).getSignalB().getRecoFlag(), JPetBaseSignal::Good);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getSignalA().getRecoFlag(), JPetBaseSignal::Good);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getSignalB().getRecoFlag(), JPetBaseSignal::Corrupted);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getSignalA().getRecoFlag(), JPetBaseSignal::Good);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getSignalB().getRecoFlag(), JPetBaseSignal::Good);
-  //
-  // BOOST_REQUIRE_EQUAL(result.at(0).getSignalA().getPM().getScin().getID(), 23);
-  // BOOST_REQUIRE_EQUAL(result.at(0).getSignalB().getPM().getScin().getID(), 23);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getSignalA().getPM().getScin().getID(), 23);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getSignalB().getPM().getScin().getID(), 23);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getSignalA().getPM().getScin().getID(), 23);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getSignalB().getPM().getScin().getID(), 23);
-  //
-  // BOOST_REQUIRE_CLOSE(result.at(0).getTime(), (1.0 + 1.5) / 2, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(1).getTime(), (4.0 + 4.8) / 2, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(2).getTime(), (6.5 + 7.2) / 2, epsilon);
-  //
-  // BOOST_REQUIRE_CLOSE(result.at(0).getTimeDiff(), 1.5 - 1.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(1).getTimeDiff(), 4.8 - 4.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(2).getTimeDiff(), 6.5 - 7.2, epsilon);
-  //
-  // BOOST_REQUIRE_CLOSE(result.at(0).getPosX(), 8.660254038, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(1).getPosX(), 8.660254038, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(2).getPosX(), 8.660254038, epsilon);
-  //
-  // BOOST_REQUIRE_CLOSE(result.at(0).getPosY(), 5.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(1).getPosY(), 5.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(2).getPosY(), 5.0, epsilon);
-  //
-  // BOOST_REQUIRE_CLOSE(result.at(0).getPosZ(), 2.0 * result.at(0).getTimeDiff() / 2000.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(1).getPosZ(), 2.0 * result.at(1).getTimeDiff() / 2000.0, epsilon);
-  // BOOST_REQUIRE_CLOSE(result.at(2).getPosZ(), 2.0 * result.at(2).getTimeDiff() / 2000.0, epsilon);
-  //
-  // BOOST_REQUIRE(result.at(0).getPosZ() > 0.0);
-  // BOOST_REQUIRE(result.at(1).getPosZ() > 0.0);
-  // BOOST_REQUIRE(result.at(2).getPosZ() < 0.0);
-  //
-  // BOOST_REQUIRE_EQUAL(result.at(0).getRecoFlag(), JPetHit::Good);
-  // BOOST_REQUIRE_EQUAL(result.at(1).getRecoFlag(), JPetHit::Corrupted);
-  // BOOST_REQUIRE_EQUAL(result.at(2).getRecoFlag(), JPetHit::Good);
+  JPetLayer layer1(1, true, "layer1", 10.0);
+  JPetBarrelSlot slot1(23, true, "barel1", 30.0, 23);
+  slot1.setLayer(layer1);
+
+  JPetScin scin1(23);
+  scin1.setBarrelSlot(slot1);
+  JPetPM pm1A(31, "1A");
+  JPetPM pm1B(75, "1B");
+  pm1A.setScin(scin1);
+  pm1B.setScin(scin1);
+  pm1A.setBarrelSlot(slot1);
+  pm1B.setBarrelSlot(slot1);
+  pm1A.setSide(JPetPM::SideA);
+  pm1B.setSide(JPetPM::SideB);
+
+  JPetTOMBChannel channel1(66);
+  JPetTOMBChannel channel2(88);
+  JPetSigCh sigCh1(JPetSigCh::Leading, 12.3);
+  JPetSigCh sigCh2(JPetSigCh::Leading, 13.4);
+  sigCh1.setTOMBChannel(channel1);
+  sigCh2.setTOMBChannel(channel2);
+  sigCh1.setThresholdNumber(1);
+  sigCh2.setThresholdNumber(1);
+  sigCh1.setPM(pm1A);
+  sigCh2.setPM(pm1B);
+
+  JPetRawSignal raw1;
+  JPetRawSignal raw2;
+  raw1.addPoint(sigCh1);
+  raw2.addPoint(sigCh2);
+  raw1.setBarrelSlot(slot1);
+  raw2.setBarrelSlot(slot1);
+
+  JPetRecoSignal reco1;
+  JPetRecoSignal reco2;
+  reco1.setRawSignal(raw1);
+  reco2.setRawSignal(raw2);
+  reco1.setBarrelSlot(slot1);
+  reco2.setBarrelSlot(slot1);
+
+  JPetPhysSignal physSig1A, physSig1B;
+  JPetPhysSignal physSig2A, physSig2B;
+  JPetPhysSignal physSig3A, physSig3B;
+  JPetPhysSignal physSigA;
+  physSigA.setBarrelSlot(slot1);
+  physSig1A.setBarrelSlot(slot1);
+  physSig1B.setBarrelSlot(slot1);
+  physSig2A.setBarrelSlot(slot1);
+  physSig2B.setBarrelSlot(slot1);
+  physSig3A.setBarrelSlot(slot1);
+  physSig3B.setBarrelSlot(slot1);
+  physSigA.setRecoSignal(reco1);
+  physSig1A.setRecoSignal(reco1);
+  physSig2A.setRecoSignal(reco1);
+  physSig3A.setRecoSignal(reco1);
+  physSig1B.setRecoSignal(reco2);
+  physSig2B.setRecoSignal(reco2);
+  physSig3B.setRecoSignal(reco2);
+  physSigA.setPM(pm1A);
+  physSig1A.setPM(pm1A);
+  physSig1B.setPM(pm1B);
+  physSig2A.setPM(pm1A);
+  physSig2B.setPM(pm1B);
+  physSig3A.setPM(pm1A);
+  physSig3B.setPM(pm1B);
+  physSig1A.setTime(1.0);
+  physSig1B.setTime(1.5);
+  physSigA.setTime(2.2);
+  physSig2A.setTime(4.0);
+  physSig2B.setTime(4.8);
+  physSig3A.setTime(7.2);
+  physSig3B.setTime(6.5);
+  physSigA.setRecoFlag(JPetBaseSignal::Good);
+  physSig1A.setRecoFlag(JPetBaseSignal::Good);
+  physSig1B.setRecoFlag(JPetBaseSignal::Good);
+  physSig2A.setRecoFlag(JPetBaseSignal::Good);
+  physSig2B.setRecoFlag(JPetBaseSignal::Corrupted);
+  physSig3A.setRecoFlag(JPetBaseSignal::Good);
+  physSig3B.setRecoFlag(JPetBaseSignal::Good);
+  std::vector<JPetPhysSignal> slotSignals;
+  slotSignals.push_back(physSigA);
+  slotSignals.push_back(physSig1A);
+  slotSignals.push_back(physSig1B);
+  slotSignals.push_back(physSig2A);
+  slotSignals.push_back(physSig2B);
+  slotSignals.push_back(physSig3A);
+  slotSignals.push_back(physSig3B);
+
+  JPetStatistics stats;
+  std::map<unsigned int, std::vector<double>> velocitiesMap;
+  std::vector<double> velVec = {2.0, 3.4, 4.5, 5.6};
+  velocitiesMap.insert(std::make_pair(66, velVec));
+  velocitiesMap.insert(std::make_pair(88, velVec));
+
+  FunctionFormula formula1 = "pol1";
+  FunctionParams params1 = {0.0, 10.0};
+  FunctionLimits limits1 = {0., 100.};
+  FuncParamsAndLimits tot2e1 = {formula1, {params1, limits1}};
+  ToTEnergyConverterFactory fact1;
+  fact1.setToTConverterOptions(tot2e1);
+
+  auto result = HitFinderTools::matchSignals(slotSignals, velocitiesMap, 1.0, fact1, stats, false);
+  auto epsilon = 0.0001;
+
+  BOOST_REQUIRE_EQUAL(result.size(), 3);
+
+  BOOST_REQUIRE_EQUAL(result.at(0).getSignalA().getPM().getID(), 31);
+  BOOST_REQUIRE_EQUAL(result.at(0).getSignalB().getPM().getID(), 75);
+  BOOST_REQUIRE_EQUAL(result.at(1).getSignalA().getPM().getID(), 31);
+  BOOST_REQUIRE_EQUAL(result.at(1).getSignalB().getPM().getID(), 75);
+  BOOST_REQUIRE_EQUAL(result.at(2).getSignalA().getPM().getID(), 31);
+  BOOST_REQUIRE_EQUAL(result.at(2).getSignalB().getPM().getID(), 75);
+
+  BOOST_REQUIRE_EQUAL(result.at(0).getSignalA().getRecoFlag(), JPetBaseSignal::Good);
+  BOOST_REQUIRE_EQUAL(result.at(0).getSignalB().getRecoFlag(), JPetBaseSignal::Good);
+  BOOST_REQUIRE_EQUAL(result.at(1).getSignalA().getRecoFlag(), JPetBaseSignal::Good);
+  BOOST_REQUIRE_EQUAL(result.at(1).getSignalB().getRecoFlag(), JPetBaseSignal::Corrupted);
+  BOOST_REQUIRE_EQUAL(result.at(2).getSignalA().getRecoFlag(), JPetBaseSignal::Good);
+  BOOST_REQUIRE_EQUAL(result.at(2).getSignalB().getRecoFlag(), JPetBaseSignal::Good);
+
+  BOOST_REQUIRE_EQUAL(result.at(0).getSignalA().getPM().getScin().getID(), 23);
+  BOOST_REQUIRE_EQUAL(result.at(0).getSignalB().getPM().getScin().getID(), 23);
+  BOOST_REQUIRE_EQUAL(result.at(1).getSignalA().getPM().getScin().getID(), 23);
+  BOOST_REQUIRE_EQUAL(result.at(1).getSignalB().getPM().getScin().getID(), 23);
+  BOOST_REQUIRE_EQUAL(result.at(2).getSignalA().getPM().getScin().getID(), 23);
+  BOOST_REQUIRE_EQUAL(result.at(2).getSignalB().getPM().getScin().getID(), 23);
+
+  BOOST_REQUIRE_CLOSE(result.at(0).getTime(), (1.0 + 1.5) / 2, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(1).getTime(), (4.0 + 4.8) / 2, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(2).getTime(), (6.5 + 7.2) / 2, epsilon);
+
+  BOOST_REQUIRE_CLOSE(result.at(0).getTimeDiff(), 1.5 - 1.0, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(1).getTimeDiff(), 4.8 - 4.0, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(2).getTimeDiff(), 6.5 - 7.2, epsilon);
+
+  BOOST_REQUIRE_CLOSE(result.at(0).getPosX(), 8.660254038, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(1).getPosX(), 8.660254038, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(2).getPosX(), 8.660254038, epsilon);
+
+  BOOST_REQUIRE_CLOSE(result.at(0).getPosY(), 5.0, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(1).getPosY(), 5.0, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(2).getPosY(), 5.0, epsilon);
+
+  BOOST_REQUIRE_CLOSE(result.at(0).getPosZ(), 2.0 * result.at(0).getTimeDiff() / 2000.0, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(1).getPosZ(), 2.0 * result.at(1).getTimeDiff() / 2000.0, epsilon);
+  BOOST_REQUIRE_CLOSE(result.at(2).getPosZ(), 2.0 * result.at(2).getTimeDiff() / 2000.0, epsilon);
+
+  BOOST_REQUIRE(result.at(0).getPosZ() > 0.0);
+  BOOST_REQUIRE(result.at(1).getPosZ() > 0.0);
+  BOOST_REQUIRE(result.at(2).getPosZ() < 0.0);
+
+  BOOST_REQUIRE_EQUAL(result.at(0).getRecoFlag(), JPetHit::Good);
+  BOOST_REQUIRE_EQUAL(result.at(1).getRecoFlag(), JPetHit::Corrupted);
+  BOOST_REQUIRE_EQUAL(result.at(2).getRecoFlag(), JPetHit::Good);
 }
 
 BOOST_AUTO_TEST_CASE(checkForPromptTest_checkTOTCalc)


### PR DESCRIPTION
This PR aims to solve the issue of creating TOT converter only when necessary, as reported in this [redmine](http://sphinx.if.uj.edu.pl/redmine/issues/1919) issue,

The ToT converter is loaded with parameters only if requested and the options are provided, otherwise, the tot factory is null and does not return generated converted, so no error messages should be logged.

The tests for Hit Finder Tools were updated and are working.